### PR TITLE
extend grammar with string exportation methods

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,7 +7,9 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    types: opened
+    types: 
+      - opened
+      - synchronize
     branches: [ "master" ]
 
 jobs:

--- a/Application/Actions/AddNonTerminal.cs
+++ b/Application/Actions/AddNonTerminal.cs
@@ -1,4 +1,6 @@
-﻿namespace Nt.Applications.SyntaxParser.Actions
+﻿using Nt.Syntax.Builders;
+
+namespace Nt.Applications.SyntaxParser.Actions
 {
     internal class AddNonTerminal(ApplicationContext context) : ProgramAction(context)
     {
@@ -26,7 +28,7 @@
                 Context.Automaton.Pop(true);
                 return;
             }
-            Context.Grammar.NonTerminals.Add(name);
+            Context.Grammar.GetBuilder().AddNonTerminal(name);
             Console.WriteLine($"Non terminal '{name}' added successfully.");
             Context.Automaton.Pop(true);
         }

--- a/Application/Actions/AddRegex.cs
+++ b/Application/Actions/AddRegex.cs
@@ -24,7 +24,7 @@ namespace Nt.Applications.SyntaxParser.Actions
 
             if (valid)
             {
-                Context.Grammar.AddRegex(regex);
+                Context.Grammar.RegularExpressions.Add(regex);
                 Console.WriteLine($"The new regular expression {regex} has been added to the grammar");
             }
             else Console.WriteLine("The regular expression was not added to the grammar due to invalid input.");

--- a/Application/Actions/AddRegex.cs
+++ b/Application/Actions/AddRegex.cs
@@ -1,4 +1,5 @@
-﻿using Nt.Syntax.Structures;
+﻿using Nt.Syntax.Builders;
+using Nt.Syntax.Structures;
 
 namespace Nt.Applications.SyntaxParser.Actions
 {
@@ -24,7 +25,7 @@ namespace Nt.Applications.SyntaxParser.Actions
 
             if (valid)
             {
-                Context.Grammar.RegularExpressions.Add(regex);
+                Context.Grammar.GetBuilder().Add(regex);
                 Console.WriteLine($"The new regular expression {regex} has been added to the grammar");
             }
             else Console.WriteLine("The regular expression was not added to the grammar due to invalid input.");

--- a/Application/Actions/AddRule.cs
+++ b/Application/Actions/AddRule.cs
@@ -24,7 +24,7 @@ namespace Nt.Applications.SyntaxParser.Actions
 
             if (valid)
             {
-                Context.Grammar.AddRule(rule);
+                Context.Grammar.Rules.Add(rule);
                 Console.WriteLine($"The new rule {rule} has been added to the grammar");
             }
             else Console.WriteLine("The rule was not added to the grammar due to invalid input.");

--- a/Application/Actions/AddRule.cs
+++ b/Application/Actions/AddRule.cs
@@ -1,4 +1,5 @@
 ﻿using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
 
 namespace Nt.Applications.SyntaxParser.Actions
 {
@@ -24,7 +25,7 @@ namespace Nt.Applications.SyntaxParser.Actions
 
             if (valid)
             {
-                Context.Grammar.Rules.Add(rule);
+                Context.Grammar.GetBuilder().Add(rule);
                 Console.WriteLine($"The new rule {rule} has been added to the grammar");
             }
             else Console.WriteLine("The rule was not added to the grammar due to invalid input.");

--- a/Application/Actions/AddTerminal.cs
+++ b/Application/Actions/AddTerminal.cs
@@ -1,4 +1,6 @@
-﻿namespace Nt.Applications.SyntaxParser.Actions
+﻿using Nt.Syntax.Builders;
+
+namespace Nt.Applications.SyntaxParser.Actions
 {
     internal class AddTerminal(ApplicationContext context) : ProgramAction(context)
     {
@@ -24,7 +26,7 @@
                 Context.Automaton.Pop(true);
                 return;
             }
-            Context.Grammar.Terminals.Add(name);
+            Context.Grammar.GetBuilder().AddTerminal(name);
             Console.WriteLine($"Terminal '{name}' added successfully.");
             Context.Automaton.Pop(true);
         }

--- a/Application/Actions/AxiomSetter.cs
+++ b/Application/Actions/AxiomSetter.cs
@@ -14,7 +14,7 @@ namespace Nt.Applications.SyntaxParser.Actions
                 Context.Automaton.Pop(true);
                 return;
             }
-            if (Context.Grammar.NonTerminals.GetCount() == 0)
+            if (Context.Grammar.NonTerminals.Count == 0)
             {
                 Console.WriteLine("There are no non terminals in the grammar. Please add some non terminals first.");
                 Context.Automaton.Pop(true);

--- a/Application/Actions/AxiomSetter.cs
+++ b/Application/Actions/AxiomSetter.cs
@@ -1,5 +1,5 @@
-﻿using Nt.Automaton.States;
-using Nt.Syntax.Structures;
+﻿using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
 
 namespace Nt.Applications.SyntaxParser.Actions
 {
@@ -41,7 +41,7 @@ namespace Nt.Applications.SyntaxParser.Actions
             try
             {
                 var symbol = Context.Grammar.NonTerminals.Get(name);
-                Context.Grammar.SetAxiom(new NonTerminal(symbol, -1));
+                Context.Grammar.GetBuilder().SetAxiom(new NonTerminal(symbol, -1));
                 Context.Automaton.Pop(true);
             }
             catch (KeyNotFoundException) 

--- a/Application/Actions/DeleteNonTerminal.cs
+++ b/Application/Actions/DeleteNonTerminal.cs
@@ -1,4 +1,6 @@
-﻿namespace Nt.Applications.SyntaxParser.Actions
+﻿using Nt.Syntax.Builders;
+
+namespace Nt.Applications.SyntaxParser.Actions
 {
     internal class DeleteNonTerminal(ApplicationContext context) : ProgramAction(context)
     {
@@ -24,7 +26,7 @@
                 Context.Automaton.Pop(true);
                 return;
             }
-            Context.Grammar.NonTerminals.Remove(name);
+            Context.Grammar.GetBuilder().RemoveNonTerminal(name);
             Console.WriteLine($"Non terminal '{name}' deleted successfully.");
             Context.Automaton.Pop(true);
         }

--- a/Application/Actions/DeleteRegex.cs
+++ b/Application/Actions/DeleteRegex.cs
@@ -1,4 +1,5 @@
 ﻿using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
 
 namespace Nt.Applications.SyntaxParser.Actions
 {
@@ -13,7 +14,7 @@ namespace Nt.Applications.SyntaxParser.Actions
                 Context.Automaton.Pop(true);
                 return;
             }
-            Context.Grammar.RegularExpressions.Remove(Regex);
+            Context.Grammar.GetBuilder().Remove(Regex);
             Console.WriteLine($"Regular expression {Regex} has been removed");
             Context.Automaton.Pop(false);
             Context.Automaton.Pop(true);

--- a/Application/Actions/DeleteRegex.cs
+++ b/Application/Actions/DeleteRegex.cs
@@ -13,7 +13,7 @@ namespace Nt.Applications.SyntaxParser.Actions
                 Context.Automaton.Pop(true);
                 return;
             }
-            Context.Grammar.Remove(Regex);
+            Context.Grammar.RegularExpressions.Remove(Regex);
             Console.WriteLine($"Regular expression {Regex} has been removed");
             Context.Automaton.Pop(false);
             Context.Automaton.Pop(true);

--- a/Application/Actions/DeleteRule.cs
+++ b/Application/Actions/DeleteRule.cs
@@ -1,5 +1,5 @@
 ﻿using Nt.Syntax.Structures;
-using System.Text.RegularExpressions;
+using Nt.Syntax.Builders;
 
 namespace Nt.Applications.SyntaxParser.Actions
 {
@@ -14,7 +14,7 @@ namespace Nt.Applications.SyntaxParser.Actions
                 Context.Automaton.Pop(true);
                 return;
             }
-            Context.Grammar.Rules.Remove(Rule);
+            Context.Grammar.GetBuilder().Remove(Rule);
             Console.WriteLine($"Rule {Rule} has been removed");
             Context.Automaton.Pop(false);
             Context.Automaton.Pop(true);

--- a/Application/Actions/DeleteRule.cs
+++ b/Application/Actions/DeleteRule.cs
@@ -14,7 +14,7 @@ namespace Nt.Applications.SyntaxParser.Actions
                 Context.Automaton.Pop(true);
                 return;
             }
-            Context.Grammar.Remove(Rule);
+            Context.Grammar.Rules.Remove(Rule);
             Console.WriteLine($"Rule {Rule} has been removed");
             Context.Automaton.Pop(false);
             Context.Automaton.Pop(true);

--- a/Application/Actions/DeleteTerminal.cs
+++ b/Application/Actions/DeleteTerminal.cs
@@ -1,4 +1,6 @@
-﻿namespace Nt.Applications.SyntaxParser.Actions
+﻿using Nt.Syntax.Builders;
+
+namespace Nt.Applications.SyntaxParser.Actions
 {
     internal class DeleteTerminal(ApplicationContext context) : ProgramAction(context)
     {
@@ -24,7 +26,7 @@
                 Context.Automaton.Pop(true);
                 return;
             }
-            Context.Grammar.Terminals.Remove(name);
+            Context.Grammar.GetBuilder().RemoveTerminal(name);
             Console.WriteLine($"Terminal '{name}' deleted successfully.");
             Context.Automaton.Pop(true);
         }

--- a/Application/Actions/GrammarLoader.cs
+++ b/Application/Actions/GrammarLoader.cs
@@ -1,4 +1,4 @@
-﻿using Nt.Automaton.States;
+﻿using Nt.Syntax.Exportation;
 using Nt.Syntax.Structures;
 
 namespace Nt.Applications.SyntaxParser.Actions

--- a/Application/Actions/SetRegexAxiom.cs
+++ b/Application/Actions/SetRegexAxiom.cs
@@ -1,4 +1,5 @@
 ﻿using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
 
 namespace Nt.Applications.SyntaxParser.Actions
 {
@@ -32,7 +33,7 @@ namespace Nt.Applications.SyntaxParser.Actions
             try
             {
                 var symbol = Context.Grammar.NonTerminals.Get(input);
-                Regex.SetToken(new NonTerminal(symbol, -1));
+                Regex.GetBuilder().SetToken(new NonTerminal(symbol, -1));
             }
             catch (KeyNotFoundException)
             {

--- a/Application/Actions/SetRegexPattern.cs
+++ b/Application/Actions/SetRegexPattern.cs
@@ -1,4 +1,5 @@
 ﻿using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
 
 namespace Nt.Applications.SyntaxParser.Actions
 {
@@ -28,7 +29,7 @@ namespace Nt.Applications.SyntaxParser.Actions
                 return false;
             }
 
-            Regex.AddSymbols(input);
+            Regex.GetBuilder().AddSymbols(input);
             return true;
         }
     }

--- a/Application/Actions/SetRuleAxiom.cs
+++ b/Application/Actions/SetRuleAxiom.cs
@@ -1,5 +1,5 @@
-﻿using Nt.Automaton.States;
-using Nt.Syntax.Structures;
+﻿using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
 
 namespace Nt.Applications.SyntaxParser.Actions
 {
@@ -34,7 +34,7 @@ namespace Nt.Applications.SyntaxParser.Actions
             try
             {
                 var symbol = Context.Grammar.NonTerminals.Get(input);
-                Rule.SetToken(new NonTerminal(symbol, -1));
+                Rule.GetBuilder().SetToken(new NonTerminal(symbol, -1));
             }
             catch (KeyNotFoundException)
             {

--- a/Application/Actions/SetRuleDerivation.cs
+++ b/Application/Actions/SetRuleDerivation.cs
@@ -1,5 +1,5 @@
-﻿using Nt.Automaton.States;
-using Nt.Syntax.Structures;
+﻿using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
 
 namespace Nt.Applications.SyntaxParser.Actions
 {
@@ -34,11 +34,11 @@ namespace Nt.Applications.SyntaxParser.Actions
             {
                 if (Context.Grammar.Terminals.Contains(token))
                 {
-                    Rule.Derivation.Add(new Terminal(Context.Grammar.Terminals.Get(token), -1));
+                    Rule.GetBuilder().Add(new Terminal(Context.Grammar.Terminals.Get(token), -1));
                 }
                 else if (Context.Grammar.NonTerminals.Contains(token))
                 {
-                    Rule.Derivation.Add(new NonTerminal(Context.Grammar.NonTerminals.Get(token), -1));
+                    Rule.GetBuilder().Add(new NonTerminal(Context.Grammar.NonTerminals.Get(token), -1));
                 }
                 else
                 {

--- a/Application/Nt.SyntaxParser.Application.csproj
+++ b/Application/Nt.SyntaxParser.Application.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>Nt.Applications.SyntaxParser</RootNamespace>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +15,13 @@
 
   <ItemGroup>
     <Folder Include="Resources\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Application/Resources/Reorder.txt
+++ b/Application/Resources/Reorder.txt
@@ -1,0 +1,23 @@
+NON TERMINALS:
+    C,
+    E,
+    G,
+    A,
+    K,
+    B;
+
+TERMINALS:
+    c,
+    e,
+    g,
+    a,
+    k,
+    b;
+
+RULES:
+    C -> c,
+    E -> e,
+    G -> g,
+    A -> a,
+    K -> k,
+    B -> b;

--- a/Doc/Exportation.md
+++ b/Doc/Exportation.md
@@ -1,0 +1,51 @@
+# Exporting a grammar
+Exporting a grammar means getting a reusable or informational object (string, grammar code, new grammar file) out of a grammar.
+
+## Why would I export?
+This project is about loading a grammar for you to edit. If there are no ways of getting this grammar back, all your editions will be lost once the editor is closed.
+Of course you can save it manually, but this project provides methods to handle it for you.
+
+## Exportation methods
+Before exporting a grammar, you must include `Nt.Syntax.Exporter` to extend the instances of grammar with exportation methods.
+The exportation methods are:
+
+
+|Method|Parameters|Return type|Comment|
+|-----------------|-----------|-------|
+|`ToString(mode)`|`mode` is one value of `ExportationMode`|string|More details below|
+|`ToString()`||string|Same as above, but `mode` is always `ExportationMode.Original`. This method is accessible without importing `Nt.Syntax.Exporter`|
+
+### Exporting as a string
+Use the method `ToString(ExportationMode mode)` to export a grammar as a user-readable grammar.
+
+The value of the `mode` parameter are:
+
+|Name|Behavior|
+|----|--------|
+|ExportationMode.Original|Order of symbols and rules in the output grammar is the same as the one are declared|
+|ExportationMode.Alphabetical|Symbols and rules are reordered in the alphabetical order|
+|ExportationMode.Grouped|Symbols with a common root in the name are grouped together. This is interesting once the grammar receives rules treatment and some symbols (terminals or non terminals) are extended from other.|
+
+## How to use
+Exportation methods are meant to be used in workflows where
+1. A grammar is created from scratch or loaded from an existing grammar file
+2. The grammar goes though various modifications, like grammar pre-treatment for further analysing
+3. An exportation method is used to store the grammar or display it to a user
+
+In your code, it will look something like this:
+
+```csharp
+using Nt.Syntax;
+using Nt.Syntax.Exporpation;
+
+var parser = new SyntaxParser();
+var grammar = parser.ParseFile("path/to/a/grammar/file");
+
+--- Various modifications ---
+
+
+-----------------------------
+
+var grammar_string = grammar.ToString(ExportationMode.Grouped);
+Console.WriteLine($"The resulting grammar is: \n{grammar_string}");
+```

--- a/Doc/Exportation.md
+++ b/Doc/Exportation.md
@@ -6,14 +6,14 @@ This project is about loading a grammar for you to edit. If there are no ways of
 Of course you can save it manually, but this project provides methods to handle it for you.
 
 ## Exportation methods
-Before exporting a grammar, you must include `Nt.Syntax.Exporter` to extend the instances of grammar with exportation methods.
+Before exporting a grammar, you must include `Nt.Syntax.Exportation` to extend the instances of grammar with exportation methods.
 The exportation methods are:
 
 
 |Method|Parameters|Return type|Comment|
 |-----------------|-----------|-------|
 |`ToString(mode)`|`mode` is one value of `ExportationMode`|string|More details below|
-|`ToString()`||string|Same as above, but `mode` is always `ExportationMode.Original`. This method is accessible without importing `Nt.Syntax.Exporter`|
+|`ToString()`||string|Same as above, but `mode` is always `ExportationMode.Original`. This method is accessible without importing `Nt.Syntax.Exportation`|
 
 ### Exporting as a string
 Use the method `ToString(ExportationMode mode)` to export a grammar as a user-readable grammar.
@@ -22,21 +22,21 @@ The value of the `mode` parameter are:
 
 |Name|Behavior|
 |----|--------|
-|ExportationMode.Original|Order of symbols and rules in the output grammar is the same as the one are declared|
+|ExportationMode.Original|Order of symbols and rules in the output grammar is the same as the one they are declared|
 |ExportationMode.Alphabetical|Symbols and rules are reordered in the alphabetical order|
 |ExportationMode.Grouped|Symbols with a common root in the name are grouped together. This is interesting once the grammar receives rules treatment and some symbols (terminals or non terminals) are extended from other.|
 
 ## How to use
 Exportation methods are meant to be used in workflows where
 1. A grammar is created from scratch or loaded from an existing grammar file
-2. The grammar goes though various modifications, like grammar pre-treatment for further analysing
+2. The grammar goes through various modifications, like grammar pre-treatment for further analysis
 3. An exportation method is used to store the grammar or display it to a user
 
 In your code, it will look something like this:
 
 ```csharp
 using Nt.Syntax;
-using Nt.Syntax.Exporpation;
+using Nt.Syntax.Exportation;
 
 var parser = new SyntaxParser();
 var grammar = parser.ParseFile("path/to/a/grammar/file");

--- a/Doc/Grammar.md
+++ b/Doc/Grammar.md
@@ -1,10 +1,11 @@
 # Grammar file syntax
 
-- [Defining symbols used in the grammar](#defining-symbols-used-in-the-grammar)
-- [Setting grammar rules](#setting-grammar-rules)
-- [Defining regular expression](#defining-regular-expressions)
-- [Setting grammar axiom](#setting-grammar-axiom)
-- [Escape characters](#escape-characters)
+- [Syntax of a grammar file](#syntax-of-a-grammar-file)
+	- [Defining symbols used in the grammar](#defining-symbols-used-in-the-grammar)
+	- [Setting grammar rules](#setting-grammar-rules)
+	- [Defining regular expression](#defining-regular-expressions)
+	- [Setting grammar axiom](#setting-grammar-axiom)
+	- [Escape characters](#escape-characters)
 - [Pre-parsing instructions](#pre-parsing-instructions)
 	- [More about importing files](#more-about-importing-files)
 	- [Configuration commands](#configuration-commands)
@@ -14,11 +15,14 @@
 	- [Defining non-terminals](#defining-non-terminals)
 	- [Defining rules](#defining-rules)
 	- [Defining regex](#defining-regex)
+	- [Setting the axiom](#setting-the-axiom)
 
 Parsing the grammar file occurs in two steps. The grammar file is first parsed to process pre-parsing lines.
 The resulted file is then parsed into the final grammar file that would be parsed into a grammar structure.
 
-## Defining symbols used in the grammar
+## Syntax of a grammar file
+
+### Defining symbols used in the grammar
 You need to provide the grammar with a list of all symbols used before using them.
 These symbols are divided into terminals (constant strings) and non terminals (symbols to derive).
 
@@ -35,7 +39,7 @@ N = {nonterminal1, nonterminal2, ...}
 
 Note that symbols defined here can contain any characthers except the symbols `,` `}` `\` or any white space. If you wish to add a symbol containing such a character into your grammar, you must use the escape character `\`.  See [the parser escape characters](../README.md#escape-character) for more details.
 
-## Setting grammar rules
+### Setting grammar rules
 You need to provide each non-terminal at least one derivation rule. The derivation can be any sequence of previously defined symbols.
 
 These rules have the following syntax:
@@ -54,7 +58,7 @@ A derivation should be followed with `;` to mark the end of the rule. Remark tha
 
 > Note that the arrow `->` can be as long as you want. It must begin with `-` and ends with a `>`. So `---->` is also valid.
 
-## Defining regular expressions
+### Defining regular expressions
 Alternatively, you define a derivation for non-terminal as a regular expression.
 Regular expressions can always be described by a grammar. However it is sometimes a hassle to set terminals, non-terminals and many rules that can make your code less manageable.
 You can use regular expressions without having to previously define the symbols used in it and define it all in just one rule. The syntax is a follow:
@@ -66,14 +70,14 @@ E: non-terminal = regex ;
 See [official microsoft documentation](https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference) to learn more about regex.
 Once again, pay attention that you need to [use escape characters](#escape-characters) for including the symbol `;`.
 
-## Setting grammar axiom
+### Setting grammar axiom
 The grammar needs a symbol to begin with for syntaxically defining if a string belongs to the grammar language. This symbol is called axiom and is defined with the syntax:
 ```
 S = axiom
 ```
 The axiom can be any non-terminal, but only one of those.
 
-## Escape characters
+### Escape characters
 Here there is a need to distinguish the [escape character for text parsing](../README.md#escape-character) and the one for syntax parsing.
 - For **text parsing**, the escape character is `\` and only ensures the next character is in the continuity of the token.
 - For **syntax parsing**, the escape character is `'` by default and is used in rules definitions to ensure the derivation symbol is treated as as part of a terminal or non terminal.
@@ -82,9 +86,15 @@ When writing a grammar, here is how to use each escape character:
 
 1. Use `\` for symbols `:`, `,`, `=`, `{`, `}`, `;`, `-`, `>`, `+`, `*` and `\` to include them in the continuity of the token. If not present, it will create a new token. Note that this escape character also works for any symbol.
 
+> Example: `a+b` will be parsed as three tokens `a`, `+` and `b`. However, if you write `a\+b`, it will be parsed as one token `a+b`.
+
 2. Use `'` in rule derivations definitions for symbols `|` and `'` to define them as rule symbols and not rule end markers. The escape character `'` can also be used for any character, though it has no effect.
 
+> Example: `R: A -> a | b ;` will be parsed as a rule with two derivations `a` and `b`. However, if you write `R: A -> a \| b \| c ;`, it will be parsed as a rule with one derivation `a | b | c`.
+
 3. To include a terminal containing `,` or `}` in a terminals set (`T={...}`), use the combination `'\,` and `'\}`
+
+> Example: `T = {a, '\,, '\}};` will be parsed as a set of three terminals `a`, `,` and `}`.
 
 4. To include `;` in a rule derivation or a regular expression, use the combination `'\;`.
 
@@ -238,5 +248,11 @@ REGULAR EXPRESSIONS:
 ```
 
 The header `REGULAR EXPRESSIONS` can also be written `Regular Expressions` or `regular expressions`.
+
+### Setting the axiom
+To set the axiom, use the syntax:
+```
+AXIOM: axiom;
+```
 
 The new syntax is entirely compatible with the old syntax and both can be used in the same file.

--- a/Domain/Actions/AddNewRegExAction.cs
+++ b/Domain/Actions/AddNewRegExAction.cs
@@ -2,6 +2,7 @@
 using Nt.Automaton.Tokens;
 using Nt.Syntax.Automaton;
 using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
 
 namespace Nt.Syntax.Actions
 {
@@ -11,7 +12,9 @@ namespace Nt.Syntax.Actions
         {
             if (word is AutomatonToken token) 
             {
-                context.Regex = grammar.AddRegex(new NonTerminal(token.Symbol, token.Line));               
+                context.Regex = new RegularExpression(grammar);
+                context.Regex.GetBuilder().SetToken(new NonTerminal(token.Symbol, token.Line));
+                grammar.RegularExpressions.Add(context.Regex);               
             }
         }
     }

--- a/Domain/Actions/AddNewRuleAction.cs
+++ b/Domain/Actions/AddNewRuleAction.cs
@@ -2,6 +2,7 @@
 using Nt.Automaton.Tokens;
 using Nt.Syntax.Automaton;
 using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
 
 namespace Nt.Syntax.Actions
 {
@@ -15,7 +16,9 @@ namespace Nt.Syntax.Actions
         {
             if (word is AutomatonToken token)
             {
-                context.Rule = grammar.AddRule(new NonTerminal(token.Symbol, token.Line));
+                context.Rule = new Rule(grammar);
+                context.Rule.GetBuilder().SetToken(new NonTerminal(token.Symbol, token.Line));
+                grammar.Rules.Add(context.Rule);
             }
         }
     }

--- a/Domain/Actions/AddNonTerminalAction.cs
+++ b/Domain/Actions/AddNonTerminalAction.cs
@@ -1,9 +1,9 @@
 ﻿using Nt.Automaton.Actions;
 using Nt.Automaton.Tokens;
-using Nt.Parser.Structures;
 using Nt.Syntax.Automaton;
 using Nt.Syntax.Exceptions;
 using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
 
 namespace Nt.Syntax.Actions
 {
@@ -24,7 +24,7 @@ namespace Nt.Syntax.Actions
             {
                 if (!context.CurrentNonTerminal.Equals(""))
                 {
-                    grammar.AddNonTerminal(grammar.RemoveEscapeCharacter(context.CurrentNonTerminal));
+                    grammar.GetBuilder().AddNonTerminal(grammar.RemoveEscapeCharacter(context.CurrentNonTerminal));
                 }
             }
             catch (RegisteredNonTerminalException) { } // Ignore those 2 exceptions for now

--- a/Domain/Actions/AddRegExSymbolsAction.cs
+++ b/Domain/Actions/AddRegExSymbolsAction.cs
@@ -3,6 +3,7 @@ using Nt.Automaton.Tokens;
 using Nt.Syntax.Automaton;
 using Nt.Syntax.Exceptions;
 using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
 
 namespace Nt.Syntax.Actions
 {
@@ -18,7 +19,7 @@ namespace Nt.Syntax.Actions
                 var new_token = grammar.RemoveEscapeCharacter(token.Symbol.Name);
 
                 // Adds the symbols to the regex
-                context.Regex.AddSymbols(new_token);
+                context.Regex.GetBuilder().AddSymbols(new_token);
             }
         }
     }

--- a/Domain/Actions/AddRuleDerivationAction.cs
+++ b/Domain/Actions/AddRuleDerivationAction.cs
@@ -1,10 +1,9 @@
 ﻿using Nt.Automaton.Actions;
 using Nt.Automaton.Tokens;
-using Nt.Parser.Structures;
 using Nt.Syntax.Automaton;
 using Nt.Syntax.Exceptions;
 using Nt.Syntax.Structures;
-using System.Data;
+using Nt.Syntax.Builders;
 
 namespace Nt.Syntax.Actions
 {
@@ -18,7 +17,7 @@ namespace Nt.Syntax.Actions
 
                 // Handles escape characters
                 var new_token = grammar.ParseToGrammarToken(token);
-                context.Rule.Add(new_token);
+                context.Rule.GetBuilder().Add(new_token);
             }
         }
     }

--- a/Domain/Actions/AddSameRuleAction.cs
+++ b/Domain/Actions/AddSameRuleAction.cs
@@ -4,6 +4,7 @@ using Nt.Automaton.Actions;
 using Nt.Automaton.Tokens;
 using Nt.Syntax.Structures;
 using Nt.Syntax.Automaton;
+using Nt.Syntax.Builders;
 
 namespace Nt.Syntax.Actions
 {
@@ -15,7 +16,10 @@ namespace Nt.Syntax.Actions
             if (context.Rule.Token == null) throw new Exception("Attempting to set a new rule with same symbol while the symbol is not defined");
             if (word is AutomatonToken token)
             {
-                context.Rule = grammar.AddRule(new NonTerminal(context.Rule.Token.Symbol, token.Line));
+                var rule = new Rule(grammar);
+                rule.GetBuilder().SetToken(new NonTerminal(context.Rule.Token.Symbol, token.Line));
+                context.Rule = rule;
+                grammar.Rules.Add(context.Rule);
             }
         }
     }

--- a/Domain/Actions/AddTerminalAction.cs
+++ b/Domain/Actions/AddTerminalAction.cs
@@ -2,6 +2,7 @@
 using Nt.Automaton.Tokens;
 using Nt.Parser.Structures;
 using Nt.Syntax.Automaton;
+using Nt.Syntax.Builders;
 using Nt.Syntax.Exceptions;
 using Nt.Syntax.Structures;
 
@@ -14,7 +15,7 @@ namespace Nt.Syntax.Actions
     public class AddTerminalAction(Grammar grammar, AutomatonContext context) : ITokenAction<string>
     {
         /// <summary>
-        /// Adds a parsed token as a new non terminal of the grammar
+        /// Adds a parsed token as a new terminal of the grammar
         /// </summary>
         /// <param name="word">Parsed token to add as new terminal</param>
         public void Perform(IAutomatonToken<string> word)
@@ -23,7 +24,7 @@ namespace Nt.Syntax.Actions
             {
                 if (!context.CurrentTerminal.Equals(""))
                 { 
-                    grammar.AddTerminal(grammar.RemoveEscapeCharacter(context.CurrentTerminal)); 
+                    grammar.GetBuilder().AddTerminal(grammar.RemoveEscapeCharacter(context.CurrentTerminal)); 
                 }
             }
             catch (RegisteredNonTerminalException) { }

--- a/Domain/Actions/SetAxiomAction.cs
+++ b/Domain/Actions/SetAxiomAction.cs
@@ -3,6 +3,7 @@ using Nt.Automaton.Tokens;
 using Nt.Syntax.Automaton;
 using Nt.Syntax.Exceptions;
 using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
 
 namespace Nt.Syntax.Actions
 {
@@ -26,7 +27,7 @@ namespace Nt.Syntax.Actions
                     var new_token = grammar.ParseToGrammarToken(token);
                     if (new_token is NonTerminal nt)
                     {
-                        grammar.SetAxiom(nt);
+                        grammar.GetBuilder().SetAxiom(nt);
                     }
                     else throw new UnregisteredNonTerminalException(new_token.Name, new_token.Line);
                 }

--- a/Domain/Actions/SetEscapeCharAction.cs
+++ b/Domain/Actions/SetEscapeCharAction.cs
@@ -16,7 +16,7 @@ namespace Nt.Syntax.Actions
                 {
                     throw new InvalidEscapeCharSymbolException(token.Symbol.Name, token.Line);
                 }
-                grammar.SetEscapeCharacter(token.Symbol.Name.ToCharArray()[0]);
+                grammar.SetEscapeChar(token.Symbol.Name.ToCharArray()[0]);
             }
         }
     }

--- a/Domain/Builders/BuilderExtensions.cs
+++ b/Domain/Builders/BuilderExtensions.cs
@@ -1,0 +1,37 @@
+﻿using Nt.Syntax.Structures;
+
+namespace Nt.Syntax.Builders
+{
+    public static class BuilderExtensions
+    {
+        /// <summary>
+        /// Get a builder for the grammar. This is useful for chaining methods.
+        /// </summary>
+        /// <param name="grammar">The <see cref="Grammar"/> instance to get a builder for.</param>
+        /// <returns>A <see cref="GrammarBuilder"/> instance for the specified grammar.</returns>
+        public static GrammarBuilder GetBuilder(this Grammar grammar)
+        {
+            return new GrammarBuilder(grammar);
+        }
+
+        /// <summary>
+        /// Get a builder for the rule. This is useful for chaining methods.
+        /// </summary>
+        /// <param name="rule">The <see cref="Rule"/> instance to get a builder for.</param>
+        /// <returns>A <see cref="RuleBuilder"/> instance for the specified rule.</returns>
+        public static RuleBuilder GetBuilder(this Rule rule)
+        {
+            return new RuleBuilder(rule);
+        }
+
+        /// <summary>
+        /// Get a builder for the regular expression. This is useful for chaining methods.
+        /// </summary>
+        /// <param name="regex">The <see cref="RegularExpression"/> instance to get a builder for.</param>
+        /// <returns>A <see cref="RegexBuilder"/> instance for the specified regular expression.</returns>
+        public static RegexBuilder GetBuilder(this RegularExpression regex)
+        {
+            return new RegexBuilder(regex);
+        }
+    }
+}

--- a/Domain/Builders/GrammarBuilder.cs
+++ b/Domain/Builders/GrammarBuilder.cs
@@ -74,6 +74,32 @@ namespace Nt.Syntax.Builders
         }
 
         /// <summary>
+        /// Remove a terminal symbol from the grammar by its name.
+        /// </summary>
+        /// <param name="name">Name of the terminal to remove.</param>
+        /// <returns>The current instance of <see cref="GrammarBuilder"/> for method chaining.</returns>
+        /// <exception cref="UnregisteredTerminalException">Thrown if the specified terminal name is not registered in the grammar.</exception>
+        public GrammarBuilder RemoveTerminal(string name)
+        {
+            if (!_grammar.Terminals.Contains(name)) throw new UnregisteredTerminalException(name, -1);
+            _grammar.Terminals.Remove(name);
+            return this;
+        }
+
+        /// <summary>
+        /// Removes a non-terminal from the grammar  by its name.
+        /// </summary>
+        /// <param name="name">Name of the non-terminal symbol to remove.</param>
+        /// <returns>The current instance of<see cref="GrammarBuilder"/> for method chaining.</returns>
+        /// <exception cref="UnregisteredNonTerminalException">Thrown if the specifed non-terminal name is not registered in the grammar.</exception>
+        public GrammarBuilder RemoveNonTerminal(string name)
+        {
+            if (!_grammar.NonTerminals.Contains(name)) throw new UnregisteredNonTerminalException(name, -1);
+            _grammar.NonTerminals.Remove(name);
+            return this;
+        }
+
+        /// <summary>
         /// Sets the axiom (start symbol) of the grammar to the specified non-terminal.
         /// </summary>
         /// <param name="name">The name of the non-terminal to set as the axiom. Cannot be null or empty. Must refer to a registered non-terminal.</param>

--- a/Domain/Builders/GrammarBuilder.cs
+++ b/Domain/Builders/GrammarBuilder.cs
@@ -1,0 +1,192 @@
+﻿using Nt.Parser.Symbols;
+using Nt.Syntax.Exceptions;
+using Nt.Syntax.Structures;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nt.Syntax.Builders
+{
+    /// <summary>
+    /// A builder class for configuring a <see cref="Grammar"/> instance.
+    /// </summary>
+    /// <param name="grammar">The <see cref="Grammar"/> instance to configure.</param>
+    public class GrammarBuilder(Grammar grammar)
+    {
+        private readonly Grammar _grammar = grammar;
+
+        /// <summary>
+        /// Add a terminal symbol to the grammar.
+        /// </summary>
+        /// <param name="name">Name of the terminal to add</param>
+        /// <returns>The current instance of <see cref="GrammarBuilder"/> for method chaining.</returns>
+        /// <exception cref="RegisteredTerminalException">Thrown if the symbol is already registered as a terminal.</exception>
+        /// <exception cref="RegisteredNonTerminalException">Thrown if the symbol is already registered as a non-terminal.</exception>
+        public GrammarBuilder AddTerminal(string name)
+        {
+            if (_grammar.Terminals.Contains(name)) throw new RegisteredTerminalException(name);
+            if (_grammar.NonTerminals.Contains(name)) throw new RegisteredNonTerminalException(name);
+            _grammar.Terminals.Add(name);
+            return this;
+        }
+
+        /// <summary>
+        /// Add a non terminal symbol to the grammar.
+        /// </summary>
+        /// <param name="name">Name of the non-terminal to add</param>
+        /// <returns>The current instance of <see cref="GrammarBuilder"/> for method chaining.</returns>
+        /// <exception cref="RegisteredNonTerminalException">Thrown if the symbol is already registered as a non-terminal.</exception>
+        /// <exception cref="RegisteredTerminalException">Thrown if the symbol is already registered as a terminal.</exception>
+        public GrammarBuilder AddNonTerminal(string name)
+        {
+            if (_grammar.NonTerminals.Contains(name)) throw new RegisteredNonTerminalException(name);
+            if (_grammar.Terminals.Contains(name)) throw new RegisteredTerminalException(name);
+            _grammar.NonTerminals.Add(name);
+            return this;
+        }
+
+        /// <summary>
+        /// Add multiple terminal symbols to the grammar.
+        /// </summary>
+        /// <param name="names">Collection of terminal names to add</param>
+        /// <returns>The current instance of <see cref="GrammarBuilder"/> for method chaining.</returns>
+        public GrammarBuilder AddTerminals(ICollection<string> names)
+        {
+            foreach (var name in names)
+            {
+                _grammar.Terminals.Add(name);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Add multiple non-terminal symbols to the grammar.
+        /// </summary>
+        /// <param name="names">Collection of non-terminal names to add</param>
+        /// <returns>The current instance of <see cref="GrammarBuilder"/> for method chaining.</returns>
+        public GrammarBuilder AddNonTerminals(ICollection<string> names)
+        {
+            foreach (var name in names)
+            {
+                _grammar.NonTerminals.Add(name);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the axiom (start symbol) of the grammar to the specified non-terminal.
+        /// </summary>
+        /// <param name="name">The name of the non-terminal to set as the axiom. Cannot be null or empty. Must refer to a registered non-terminal.</param>
+        /// <returns>The current instance of <see cref="GrammarBuilder"/> to allow method chaining.</returns>
+        /// <exception cref="UnregisteredNonTerminalException">Thrown if the specified non-terminal name is not registered in the grammar.</exception>
+        public GrammarBuilder SetAxiom(string name)
+        {
+            try
+            {
+                var symbol = _grammar.NonTerminals.Get(name);
+                if (!_grammar.NonTerminals.Contains(symbol.Name)) throw new UnregisteredNonTerminalException(name, -1);
+                _grammar.Axiom = new NonTerminal(symbol, -1);
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new UnregisteredNonTerminalException(name, -1);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the axiom (start symbol) of the grammar to the specified non-terminal symbol.
+        /// </summary>
+        /// <param name="symbol">The symbol to set as the axiom. Must be a non-terminal symbol defined in the grammar.</param>
+        /// <returns>The current instance of <see cref="GrammarBuilder"/> to allow method chaining.</returns>
+        /// <exception cref="UnregisteredNonTerminalException">Thrown if <paramref name="symbol"/> is not a non-terminal symbol in the grammar.</exception>
+        public GrammarBuilder SetAxiom(Symbol symbol)
+        {
+            try
+            {
+                if (!_grammar.NonTerminals.Contains(symbol.Name)) throw new UnregisteredNonTerminalException(symbol.Name, -1);
+                _grammar.Axiom = new NonTerminal(symbol, -1);
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new UnregisteredNonTerminalException(symbol.Name, -1);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the axiom (start symbol) of the grammar to the specified non-terminal token.
+        /// </summary>
+        /// <param name="token">The non-terminal token to use as the axiom of the grammar. Cannot be null.</param>
+        /// <returns>The current instance of <see cref="GrammarBuilder"/> for method chaining.</returns>
+        /// <exception cref="UnregisteredNonTerminalException">Thrown if <paramref name="token"/> is not a non-terminal symbol in the grammar.</exception>
+        public GrammarBuilder SetAxiom(NonTerminal token)
+        {
+            try
+            {
+                if (!_grammar.NonTerminals.Contains(token.Name)) throw new UnregisteredNonTerminalException(token.Name, token.Line);
+                _grammar.Axiom = token;
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new UnregisteredNonTerminalException(token.Name, token.Line);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Add a rule to the grammar
+        /// </summary>
+        /// <param name="rule">Rule to add</param>
+        /// <returns>The current instance of <see cref="GrammarBuilder"/> for method chaining.</returns>
+        public GrammarBuilder Add(Rule rule)
+        {
+            _grammar.Rules.Add(rule);
+            return this;
+        }
+
+        /// <summary>
+        /// Add a regular expression to the grammar
+        /// </summary>
+        /// <param name="regex">Regular expression to add</param>
+        /// <returns>The current instance of <see cref="GrammarBuilder"/> for method chaining.</returns>
+        public GrammarBuilder Add(RegularExpression regex)
+        {
+            _grammar.RegularExpressions.Add(regex);
+            return this;
+        }
+
+        /// <summary>
+        /// Remove the specified rule from the grammar.
+        /// </summary>
+        /// <param name="rule">Rule to remove</param>
+        /// <returns>The current instance of <see cref="GrammarBuilder"/> for method chaining.</returns>
+        /// <exception cref="RuleNotFoundException">Thrown if the specified rule is not found in the grammar.</exception>
+        public GrammarBuilder Remove(Rule rule)
+        {
+            _grammar.Rules.Remove(rule);
+            return this;
+        }
+
+        /// <summary>
+        /// Removes the specified regular expression from the grammar.
+        /// </summary>
+        /// <param name="regex">The regular expression to remove from the grammar. Cannot be null.</param>
+        /// <returns>The current instance of <see cref="GrammarBuilder"/> for method chaining.</returns>
+        public GrammarBuilder Remove(RegularExpression regex)
+        {
+            _grammar.RegularExpressions.Remove(regex);
+            return this;
+        }
+
+        /// <summary>
+        /// Builds and returns the configured Grammar instance.
+        /// </summary>
+        /// <returns>The <see cref="Grammar"/> instance this builder refers to.</returns>
+        public Grammar Build()
+        {
+            return _grammar;
+        }
+
+    }
+}

--- a/Domain/Builders/RegexBuilder.cs
+++ b/Domain/Builders/RegexBuilder.cs
@@ -1,0 +1,47 @@
+﻿using Nt.Syntax.Exceptions;
+using Nt.Syntax.Structures;
+
+namespace Nt.Syntax.Builders
+{
+    /// <summary>
+    /// A builder class for configurating a <see cref="RegularExpression"/> instance
+    /// </summary>
+    /// <param name="regex">The regular expression this builder configures</param>
+    public class RegexBuilder(RegularExpression regex)
+    {
+        private readonly RegularExpression _regex = regex;
+
+        /// <summary>
+        /// Set the non-terminal to derive the regular expression from.
+        /// </summary>
+        /// <param name="nt">Non-terminal to set</param>
+        /// <returns>This instance of <see cref="RegexBuilder"/> for method chaining</returns>
+        /// <exception cref="UnregisteredNonTerminalException">Thrown if the <paramref name="nt"/> is not registered in the grammar.</exception>
+        public RegexBuilder SetToken(NonTerminal nt)
+        {
+            if (!_regex.Grammar.NonTerminals.Contains(nt.Name)) throw new UnregisteredNonTerminalException(nt.Name, nt.Line);
+            _regex.Token = nt;
+            return this;
+        }
+
+        /// <summary>
+        /// Add a pattern to the current pattern of the regular expression.
+        /// </summary>
+        /// <param name="pattern">Pattern to add</param>
+        /// <returns>This instance of <see cref="RegexBuilder"/> for method chaining</returns>
+        public RegexBuilder AddSymbols(string pattern)
+        {
+            _regex.Pattern += pattern;
+            return this;
+        }
+
+        /// <summary>
+        /// Builds and returns the configured regular expression instance.
+        /// </summary>
+        /// <returns>The <see cref="RegularExpression"/> object representing the constructed regular expression.</returns>
+        public RegularExpression Build()
+        {
+            return _regex;
+        }
+    }
+}

--- a/Domain/Builders/RuleBuilder.cs
+++ b/Domain/Builders/RuleBuilder.cs
@@ -1,0 +1,65 @@
+﻿using Nt.Syntax.Exceptions;
+using Nt.Syntax.Structures;
+
+namespace Nt.Syntax.Builders
+{
+    /// <summary>
+    /// A builder class for configuring a <see cref="Rule"/> instance.
+    /// </summary>
+    /// <param name="rule">The rule this builder configures</param>
+    public class RuleBuilder(Rule rule)
+    {
+        private readonly Rule _rule = rule;
+
+        /// <summary>
+        /// Sets the token for the rule using the specified non-terminal symbol.
+        /// </summary>
+        /// <param name="nt">The non-terminal symbol the rule must derive.</param>
+        /// <returns>The current instance of <see cref="RuleBuilder"/> for method chaining.</returns>
+        /// <exception cref="UnregisteredNonTerminalException">Thrown if <paramref name="nt"/> is not registered in the grammar's collection of non-terminals.</exception>
+        public RuleBuilder SetToken(NonTerminal nt)
+        {
+            if (!_rule.Grammar.NonTerminals.Contains(nt.Name)) throw new UnregisteredNonTerminalException(nt.Name, nt.Line);
+            _rule.Token = nt;
+            return this;
+        }
+
+        /// <summary>
+        /// Add a <see cref="GrammarToken"/> to the rule's derivation sequence.
+        /// </summary>
+        /// <param name="token">Grammar token to add. Can be either a terminal or non-terminal symbol.</param>
+        /// <returns>The current instance of <see cref="RuleBuilder"/> for method chaining.</returns>
+        /// <exception cref="UnknownSymbolException">Thrown if <paramref name="token"/> is neither registered as a terminal or non terminal.</exception>
+        public RuleBuilder Add(GrammarToken token)
+        {
+            if (!_rule.Grammar.Terminals.Contains(token.Name) && !_rule.Grammar.NonTerminals.Contains(token.Name))
+                throw new UnknownSymbolException(token.Name, token.Line);
+            _rule.Derivation.Add(token);
+            return this;
+        }
+        
+        /// <summary>
+        /// Insert a <see cref="GrammarToken"/> at the specified position in the rule's derivation sequence.
+        /// </summary>
+        /// <param name="position">The position at which to insert the token.</param>
+        /// <param name="token">Grammar token to insert. Can be either a terminal or non-terminal symbol.</param>
+        /// <returns>The current instance of <see cref="RuleBuilder"/> for method chaining.</returns>
+        /// <exception cref="UnknownSymbolException">Thrown if <paramref name="token"/> is neither registered as a terminal or non terminal.</exception>
+        public RuleBuilder Insert(int position, GrammarToken token)
+        {
+            if (!_rule.Grammar.Terminals.Contains(token.Name) && !_rule.Grammar.NonTerminals.Contains(token.Name))
+                throw new UnknownSymbolException(token.Name, token.Line);
+            _rule.Derivation.Insert(position, token);
+            return this;
+        }
+
+        /// <summary>
+        /// Build and return the configured rule instance.
+        /// </summary>
+        /// <returns>The instance of <see cref="Rule"/> representing the constructed rule.</returns>
+        public Rule Build()
+        {
+            return _rule;
+        }
+    }
+}

--- a/Domain/Exportation/ExportationMethods.cs
+++ b/Domain/Exportation/ExportationMethods.cs
@@ -1,0 +1,123 @@
+﻿using Nt.Parser.Symbols;
+using Nt.Syntax.Structures;
+
+namespace Nt.Syntax.Exportation
+{
+    public static class ExportationMethods
+    {
+        public static List<ISymbol> Reorder(List<ISymbol> symbols, ExportationMode mode)
+        {
+            switch (mode)
+            {
+                case ExportationMode.Original:
+                    return symbols;
+                case ExportationMode.Alphabetical:
+                    return [.. symbols.OrderBy(symbol => symbol.Name)];
+                case ExportationMode.Grouped:
+                    var queue = new List<ISymbol>(symbols);
+                    var ordered_symbols = new List<ISymbol>();
+                    while (queue.Count > 0)
+                    {
+                        var current_symbol = queue[0];
+                        var similar_symbols = queue.Where(symbol => symbol.Name.StartsWith(current_symbol.Name)).ToList();
+                        foreach (var symbol in similar_symbols)
+                        {
+                            ordered_symbols.Add(symbol);
+                            queue.Remove(symbol);
+                        }
+                    }
+                    return ordered_symbols;
+            }
+            return symbols;
+        }
+
+        public static List<Rule> Reorder(List<Rule> rules, ExportationMode mode)
+        {
+            switch (mode)
+            {
+                case ExportationMode.Original:
+                    return rules;
+                case ExportationMode.Alphabetical:
+                    var queue = new List<Rule>(rules.OrderBy(rule => rule.Token?.Name));
+                    var ordered_rules = new List<Rule>();
+                    while (queue.Count > 0)
+                    {
+                        var current_rule = queue[0];
+                        ordered_rules.Add(current_rule);
+                        queue.RemoveAt(0);
+                        var similar_rules = queue.Where(rule => rule.Token?.Name == current_rule.Token?.Name).OrderBy(rule => rule.ToString()).ToList();
+                        foreach (var rule in similar_rules)
+                        {
+                            ordered_rules.Add(rule);
+                            queue.Remove(rule);
+                        }
+                    }
+                    return ordered_rules;
+                case ExportationMode.Grouped:
+                    queue = [.. rules];
+                    ordered_rules = [];
+                    while (queue.Count > 0)
+                    {
+                        var current_rule = queue[0];
+                        ordered_rules.Add(current_rule);
+                        queue.RemoveAt(0);
+                        if (current_rule.Token == null) continue;
+                        var similar_rules = queue.Where(rule => rule.Token != null && rule.Token.Name.StartsWith(current_rule.Token.Name)).ToList();
+                        foreach (var rule in similar_rules)
+                        {
+                            ordered_rules.Add(rule);
+                            queue.Remove(rule);
+                        }
+                    }
+                    return ordered_rules;
+            }
+            return rules;
+        }
+
+        public static List<RegularExpression> Reorder(List<RegularExpression> regexes, ExportationMode mode)
+        {
+            switch (mode)
+            {
+                case ExportationMode.Original:
+                    return regexes;
+                case ExportationMode.Alphabetical:
+                    var queue = new List<RegularExpression>(regexes.OrderBy(regex => regex.Token?.Name));
+                    var ordered_regexes = new List<RegularExpression>();
+                    while (queue.Count > 0)
+                    {
+                        var current_regex = queue[0];
+                        ordered_regexes.Add(current_regex);
+                        queue.RemoveAt(0);
+
+                        var similar_regexes = queue.Where(regex => regex.Token?.Name == current_regex.Token?.Name).OrderBy(regex => regex.ToString()).ToList();
+                        foreach (var regex in similar_regexes)
+                        {
+                            ordered_regexes.Add(regex);
+                            queue.Remove(regex);
+                        }
+                    }
+                    return ordered_regexes;
+                case ExportationMode.Grouped:
+                    queue = [.. regexes];
+                    ordered_regexes = [];
+                    while (queue.Count > 0)
+                    {
+                        var current_regex = queue[0];
+                        ordered_regexes.Add(current_regex);
+                        queue.RemoveAt(0);
+
+                        if (current_regex.Token == null) continue;
+                        var similar_regexes = queue.Where(regex => regex.Token != null && regex.Token.Name.StartsWith(current_regex.Token.Name)).ToList();
+                        foreach (var regex in similar_regexes)
+                        {
+                            ordered_regexes.Add(regex);
+                            queue.Remove(regex);
+                        }
+                    }
+                    return ordered_regexes;
+            }
+            return regexes;
+        }
+
+    }
+}

--- a/Domain/Exportation/StringExporter.cs
+++ b/Domain/Exportation/StringExporter.cs
@@ -1,0 +1,56 @@
+﻿using Nt.Parser.Structures;
+using Nt.Parser.Symbols;
+using Nt.Syntax.Structures;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nt.Syntax.Exportation
+{
+
+    internal class StringExporter
+    {
+
+        public static string ToString(IEnumerable<ISymbol> symbols)
+        {
+            var sb = new StringBuilder();
+            foreach(var symbol in symbols)
+            {
+                sb.AppendLine($"- {symbol}");
+            }
+            return sb.ToString();
+        }
+
+        public static string ToString(IEnumerable<Rule> rules)
+        {
+            var sb = new StringBuilder();
+            foreach (var rule in rules)
+            {
+                sb.AppendLine($"- {rule}");
+            }
+            return sb.ToString();
+        }
+
+        public static string ToString(IEnumerable<RegularExpression> regexes)
+        {
+            var sb = new StringBuilder();
+            foreach (var regex in regexes)
+            {
+                sb.AppendLine($"- {regex}");
+            }
+            return sb.ToString();
+        }
+
+        public static string ToString(IEnumerable<ISymbol> terminals, IEnumerable<ISymbol> nonterminals, NonTerminal? axiom, IEnumerable<Rule> rules, IEnumerable<RegularExpression> regexes)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"Terminals:\n {ToString(terminals)}");
+            sb.AppendLine($"Nonterminals:\n {ToString(nonterminals)}");
+            if (axiom != null) sb.AppendLine($"Axiom: {axiom}");
+            if (rules.Any()) sb.AppendLine($"Rules:\n{ToString(rules)}");
+            if (regexes.Any()) sb.AppendLine($"Regular Expressions:\n{ToString(regexes)}");
+            return sb.ToString();
+        }
+
+    }
+}

--- a/Domain/Exportation/StringExporter.cs
+++ b/Domain/Exportation/StringExporter.cs
@@ -1,8 +1,5 @@
-﻿using Nt.Parser.Structures;
-using Nt.Parser.Symbols;
+﻿using Nt.Parser.Symbols;
 using Nt.Syntax.Structures;
-using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace Nt.Syntax.Exportation
@@ -10,7 +7,6 @@ namespace Nt.Syntax.Exportation
 
     internal class StringExporter
     {
-
         public static string ToString(IEnumerable<ISymbol> symbols)
         {
             var sb = new StringBuilder();

--- a/Domain/Exportation/StringExporter.cs
+++ b/Domain/Exportation/StringExporter.cs
@@ -44,8 +44,8 @@ namespace Nt.Syntax.Exportation
         public static string ToString(IEnumerable<ISymbol> terminals, IEnumerable<ISymbol> nonterminals, NonTerminal? axiom, IEnumerable<Rule> rules, IEnumerable<RegularExpression> regexes)
         {
             var sb = new StringBuilder();
-            sb.AppendLine($"Terminals:\n {ToString(terminals)}");
-            sb.AppendLine($"Nonterminals:\n {ToString(nonterminals)}");
+            sb.AppendLine($"Terminals:\n{ToString(terminals)}");
+            sb.AppendLine($"Nonterminals:\n{ToString(nonterminals)}");
             if (axiom != null) sb.AppendLine($"Axiom: {axiom}");
             if (rules.Any()) sb.AppendLine($"Rules:\n{ToString(rules)}");
             if (regexes.Any()) sb.AppendLine($"Regular Expressions:\n{ToString(regexes)}");

--- a/Domain/Exportation/StringExporterExtensions.cs
+++ b/Domain/Exportation/StringExporterExtensions.cs
@@ -176,8 +176,8 @@ namespace Nt.Syntax.Exportation
         {
             var terminals = Reorder(grammar.Terminals.GetSymbols(), mode);
             var nonterminals = Reorder(grammar.NonTerminals.GetSymbols(), mode);
-            var rules = Reorder(grammar.Rules, grammar.NonTerminals.GetSymbols(), mode);
-            var regexes = Reorder(grammar.RegularExpressions, grammar.NonTerminals.GetSymbols(), mode);
+            var rules = Reorder(grammar.Rules, mode);
+            var regexes = Reorder(grammar.RegularExpressions, mode);
             return StringExporter.ToString(terminals, nonterminals, grammar.Axiom, rules, regexes);
         }
 

--- a/Domain/Exportation/StringExporterExtensions.cs
+++ b/Domain/Exportation/StringExporterExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Nt.Parser.Structures;
-using Nt.Parser.Symbols;
 using Nt.Syntax.Structures;
+using static Nt.Syntax.Exportation.ExportationMethods;
 
 namespace Nt.Syntax.Exportation
 {
@@ -13,120 +13,6 @@ namespace Nt.Syntax.Exportation
 
     public static class StringExporterExtensions
     {
-        private static IEnumerable<ISymbol> Reorder(IEnumerable<ISymbol> symbols, ExportationMode mode)
-        {
-            switch (mode)
-            {
-                case ExportationMode.Original:
-                    return symbols;
-                case ExportationMode.Alphabetical:
-                    return symbols.OrderBy(symbol => symbol.Name);
-                case ExportationMode.Grouped:
-                    var queue = new List<ISymbol>(symbols);
-                    var ordered_symbols = new List<ISymbol>();
-                    while (queue.Count > 0)
-                    {
-                        var current_symbol = queue[0];
-                        ordered_symbols.Add(current_symbol);
-                        var similar_symbols = queue.Where(symbol => symbol.Name.StartsWith(current_symbol.Name));
-                        foreach (var symbol in similar_symbols)
-                        {
-                            ordered_symbols.Add(symbol);
-                            queue.Remove(symbol);
-                        }
-                    }
-                    return ordered_symbols;
-            }
-            return symbols;
-        }
-
-        private static IEnumerable<Rule> Reorder(IEnumerable<Rule> rules, ExportationMode mode)
-        {
-            switch (mode)
-            {
-                case ExportationMode.Original:
-                    return rules;
-                case ExportationMode.Alphabetical:
-                    var queue = new List<Rule>(rules.OrderBy(rule => rule.Token?.Name));
-                    var ordered_rules = new List<Rule>();
-                    while (queue.Count > 0)
-                    {
-                        var current_rule = queue[0];
-                        ordered_rules.Add(current_rule);
-                        queue.RemoveAt(0);
-                        var similar_rules = queue.Where(rule => rule.Token?.Name == current_rule.Token?.Name).OrderBy(rule => rule.ToString());
-                        foreach (var rule in similar_rules)
-                        {
-                            ordered_rules.Add(rule);
-                            queue.Remove(rule);
-                        }
-                    }
-                    return ordered_rules;
-                case ExportationMode.Grouped:
-                    queue = [.. rules];
-                    ordered_rules = [];
-                    while (queue.Count > 0)
-                    {
-                        var current_rule = queue[0];
-                        ordered_rules.Add(current_rule);
-                        queue.RemoveAt(0);
-                        if (current_rule.Token == null) continue;
-                        var similar_rules = queue.Where(rule => rule.Token != null && rule.Token.Name.StartsWith(current_rule.Token.Name));
-                        foreach (var rule in similar_rules)
-                        {
-                            ordered_rules.Add(rule);
-                            queue.Remove(rule);
-                        }
-                    }
-                    return ordered_rules;
-            }
-            return rules;
-        }
-
-        private static IEnumerable<RegularExpression> Reorder(IEnumerable<RegularExpression> regexes, ExportationMode mode)
-        {
-            switch (mode)
-            {
-                case ExportationMode.Original:
-                    return regexes;
-                case ExportationMode.Alphabetical:
-                    var queue = new List<RegularExpression>(regexes.OrderBy(regex => regex.Token?.Name));
-                    var ordered_regexes = new List<RegularExpression>();
-                    while (queue.Count > 0)
-                    {
-                        var current_regex = queue[0];
-                        ordered_regexes.Add(current_regex);
-                        queue.RemoveAt(0);
-
-                        var similar_regexes = queue.Where(regex => regex.Token?.Name == current_regex.Token?.Name).OrderBy(regex => regex.ToString());
-                        foreach (var regex in similar_regexes)
-                        {
-                            ordered_regexes.Add(regex);
-                            queue.Remove(regex);
-                        }
-                    }
-                    return ordered_regexes;
-                case ExportationMode.Grouped:
-                    queue = [.. regexes];
-                    ordered_regexes = [];
-                    while (queue.Count > 0)
-                    {
-                        var current_regex = queue[0];
-                        ordered_regexes.Add(current_regex);
-                        queue.RemoveAt(0);
-
-                        if (current_regex.Token == null) continue;
-                        var similar_regexes = queue.Where(regex => regex.Token != null && regex.Token.Name.StartsWith(current_regex.Token.Name));
-                        foreach (var regex in similar_regexes)
-                        {
-                            ordered_regexes.Add(regex);
-                            queue.Remove(regex);
-                        }
-                    }
-                    return ordered_regexes;
-            }
-            return regexes;
-        }
 
         /// <summary>
         /// Export a collection of symbols to string with the specified exportation mode.
@@ -149,7 +35,7 @@ namespace Nt.Syntax.Exportation
         /// <returns>A string representation of the grammar rules, formatted according to the specified nonterminals and exportation mode.</returns>
         public static string ToString(this RulesSet rules, ExportationMode mode)
         {
-            var ordered_rules = Reorder(rules, mode);
+            var ordered_rules = Reorder(rules.ToList(), mode);
             return StringExporter.ToString(ordered_rules);
         }
 
@@ -160,9 +46,9 @@ namespace Nt.Syntax.Exportation
         /// <param name="nonterminals">An ordered collection of nonterminal symbols that determines the output order of the regular expressions.</param>
         /// <param name="mode">The exportation mode that specifies formatting or output rules for the conversion.</param>
         /// <returns>A string representation of the regular expressions, formatted according to the specified nonterminals and exportation mode.</returns>
-        public static string ToString(this RegExpSet regexes, ExportationMode mode)
+        public static string ToString(this RegexSet regexes, ExportationMode mode)
         {
-            var ordered_regexes = Reorder(regexes, mode);
+            var ordered_regexes = Reorder(regexes.ToList(), mode);
             return StringExporter.ToString(ordered_regexes);
         }
 
@@ -176,8 +62,8 @@ namespace Nt.Syntax.Exportation
         {
             var terminals = Reorder(grammar.Terminals.GetSymbols(), mode);
             var nonterminals = Reorder(grammar.NonTerminals.GetSymbols(), mode);
-            var rules = Reorder(grammar.Rules, mode);
-            var regexes = Reorder(grammar.RegularExpressions, mode);
+            var rules = Reorder(grammar.Rules.ToList(), mode);
+            var regexes = Reorder(grammar.RegularExpressions.ToList(), mode);
             return StringExporter.ToString(terminals, nonterminals, grammar.Axiom, rules, regexes);
         }
 

--- a/Domain/Exportation/StringExporterExtensions.cs
+++ b/Domain/Exportation/StringExporterExtensions.cs
@@ -1,0 +1,185 @@
+﻿using Nt.Parser.Structures;
+using Nt.Parser.Symbols;
+using Nt.Syntax.Structures;
+
+namespace Nt.Syntax.Exportation
+{
+    public enum ExportationMode
+    {
+        Original,
+        Alphabetical,
+        Grouped
+    }
+
+    public static class StringExporterExtensions
+    {
+        private static IEnumerable<ISymbol> Reorder(IEnumerable<ISymbol> symbols, ExportationMode mode)
+        {
+            switch (mode)
+            {
+                case ExportationMode.Original:
+                    return symbols;
+                case ExportationMode.Alphabetical:
+                    return symbols.OrderBy(symbol => symbol.Name);
+                case ExportationMode.Grouped:
+                    var queue = new List<ISymbol>(symbols);
+                    var ordered_symbols = new List<ISymbol>();
+                    while (queue.Count > 0)
+                    {
+                        var current_symbol = queue[0];
+                        ordered_symbols.Add(current_symbol);
+                        var similar_symbols = queue.Where(symbol => symbol.Name.StartsWith(current_symbol.Name));
+                        foreach (var symbol in similar_symbols)
+                        {
+                            ordered_symbols.Add(symbol);
+                            queue.Remove(symbol);
+                        }
+                    }
+                    return ordered_symbols;
+            }
+            return symbols;
+        }
+
+        private static IEnumerable<Rule> Reorder(IEnumerable<Rule> rules, ExportationMode mode)
+        {
+            switch (mode)
+            {
+                case ExportationMode.Original:
+                    return rules;
+                case ExportationMode.Alphabetical:
+                    var queue = new List<Rule>(rules.OrderBy(rule => rule.Token?.Name));
+                    var ordered_rules = new List<Rule>();
+                    while (queue.Count > 0)
+                    {
+                        var current_rule = queue[0];
+                        ordered_rules.Add(current_rule);
+                        queue.RemoveAt(0);
+                        var similar_rules = queue.Where(rule => rule.Token?.Name == current_rule.Token?.Name).OrderBy(rule => rule.ToString());
+                        foreach (var rule in similar_rules)
+                        {
+                            ordered_rules.Add(rule);
+                            queue.Remove(rule);
+                        }
+                    }
+                    return ordered_rules;
+                case ExportationMode.Grouped:
+                    queue = [.. rules];
+                    ordered_rules = [];
+                    while (queue.Count > 0)
+                    {
+                        var current_rule = queue[0];
+                        ordered_rules.Add(current_rule);
+                        queue.RemoveAt(0);
+                        if (current_rule.Token == null) continue;
+                        var similar_rules = queue.Where(rule => rule.Token != null && rule.Token.Name.StartsWith(current_rule.Token.Name));
+                        foreach (var rule in similar_rules)
+                        {
+                            ordered_rules.Add(rule);
+                            queue.Remove(rule);
+                        }
+                    }
+                    return ordered_rules;
+            }
+            return rules;
+        }
+
+        private static IEnumerable<RegularExpression> Reorder(IEnumerable<RegularExpression> regexes, ExportationMode mode)
+        {
+            switch (mode)
+            {
+                case ExportationMode.Original:
+                    return regexes;
+                case ExportationMode.Alphabetical:
+                    var queue = new List<RegularExpression>(regexes.OrderBy(regex => regex.Token?.Name));
+                    var ordered_regexes = new List<RegularExpression>();
+                    while (queue.Count > 0)
+                    {
+                        var current_regex = queue[0];
+                        ordered_regexes.Add(current_regex);
+                        queue.RemoveAt(0);
+
+                        var similar_regexes = queue.Where(regex => regex.Token?.Name == current_regex.Token?.Name).OrderBy(regex => regex.ToString());
+                        foreach (var regex in similar_regexes)
+                        {
+                            ordered_regexes.Add(regex);
+                            queue.Remove(regex);
+                        }
+                    }
+                    return ordered_regexes;
+                case ExportationMode.Grouped:
+                    queue = [.. regexes];
+                    ordered_regexes = [];
+                    while (queue.Count > 0)
+                    {
+                        var current_regex = queue[0];
+                        ordered_regexes.Add(current_regex);
+                        queue.RemoveAt(0);
+
+                        if (current_regex.Token == null) continue;
+                        var similar_regexes = queue.Where(regex => regex.Token != null && regex.Token.Name.StartsWith(current_regex.Token.Name));
+                        foreach (var regex in similar_regexes)
+                        {
+                            ordered_regexes.Add(regex);
+                            queue.Remove(regex);
+                        }
+                    }
+                    return ordered_regexes;
+            }
+            return regexes;
+        }
+
+        /// <summary>
+        /// Export a collection of symbols to string with the specified exportation mode.
+        /// </summary>
+        /// <param name="symbols">List of symbols to export</param>
+        /// <param name="mode">Mode to export the list of symbols</param>
+        /// <returns>A string representing this list of symbols</returns>
+        public static string ToString(this SymbolsList symbols, ExportationMode mode)
+        {
+            var ordered_symbols = Reorder(symbols.GetSymbols(), mode);
+            return StringExporter.ToString(ordered_symbols);
+        }
+
+        /// <summary>
+        /// Export a set of grammar rules to its string representation using the given nonterminals and exportation mode.
+        /// </summary>
+        /// <param name="rules">The set of grammar rules to convert to a string.</param>
+        /// <param name="nonterminals">An ordered collection of nonterminal symbols that determines the output order of the rules.</param>
+        /// <param name="mode">The exportation mode that specifies formatting or filtering options for the output.</param>
+        /// <returns>A string representation of the grammar rules, formatted according to the specified nonterminals and exportation mode.</returns>
+        public static string ToString(this RulesSet rules, ExportationMode mode)
+        {
+            var ordered_rules = Reorder(rules, mode);
+            return StringExporter.ToString(ordered_rules);
+        }
+
+        /// <summary>
+        /// Export a set of regular expressions to a string representation according to the provided nonterminals and exportation mode.
+        /// </summary>
+        /// <param name="regexes">The set of regular expressions to convert.</param>
+        /// <param name="nonterminals">An ordered collection of nonterminal symbols that determines the output order of the regular expressions.</param>
+        /// <param name="mode">The exportation mode that specifies formatting or output rules for the conversion.</param>
+        /// <returns>A string representation of the regular expressions, formatted according to the specified nonterminals and exportation mode.</returns>
+        public static string ToString(this RegExpSet regexes, ExportationMode mode)
+        {
+            var ordered_regexes = Reorder(regexes, mode);
+            return StringExporter.ToString(ordered_regexes);
+        }
+
+        /// <summary>
+        /// Export a grammar to string with the specified exportation mode.
+        /// </summary>
+        /// <param name="grammar">Grammar to export</param>
+        /// <param name="mode">Mode to export the grammar</param>
+        /// <returns>A string representing the grammar</returns>
+        public static string ToString(this Grammar grammar, ExportationMode mode)
+        {
+            var terminals = Reorder(grammar.Terminals.GetSymbols(), mode);
+            var nonterminals = Reorder(grammar.NonTerminals.GetSymbols(), mode);
+            var rules = Reorder(grammar.Rules, grammar.NonTerminals.GetSymbols(), mode);
+            var regexes = Reorder(grammar.RegularExpressions, grammar.NonTerminals.GetSymbols(), mode);
+            return StringExporter.ToString(terminals, nonterminals, grammar.Axiom, rules, regexes);
+        }
+
+    }
+}

--- a/Domain/Nt.SyntaxParser.Domain.csproj
+++ b/Domain/Nt.SyntaxParser.Domain.csproj
@@ -8,7 +8,7 @@
     <PackageId>Nt.SyntaxParser</PackageId>
     <AssemblyName>Nt.SyntaxParser</AssemblyName>
     <RootNamespace>Nt.Syntax</RootNamespace>
-    <Version>1.1.4</Version>
+    <Version>1.2.0</Version>
     <Authors>Natvs</Authors>
     <Description>Library containing tools for syntax parsing.
 Includes a grammar string parser and a simple text parser.</Description>
@@ -16,7 +16,7 @@ Includes a grammar string parser and a simple text parser.</Description>
     <RepositoryUrl>https://github.com/Natvs/Nt.SyntaxParser</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>parser ; grammar ; syntax</PackageTags>
-    <PackageReleaseNotes>Update dependency version Nt.Automaton to 1.1.0</PackageReleaseNotes>
+    <PackageReleaseNotes>Add string exportation methods for grammar with 3 different modes.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,6 +26,13 @@ Includes a grammar string parser and a simple text parser.</Description>
     <EmbeddedResource Remove="obj\**" />
     <None Remove="bin\**" />
     <None Remove="obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Domain/Structures/Grammar.cs
+++ b/Domain/Structures/Grammar.cs
@@ -1,5 +1,4 @@
 ﻿using Nt.Parser.Structures;
-using Nt.Parser.Symbols;
 using Nt.Syntax.Exceptions;
 using Nt.Syntax.Exportation;
 
@@ -14,8 +13,8 @@ namespace Nt.Syntax.Structures
         public Grammar()
         {
             var configuration = SyntaxParserConfig.GetInstance();
-            Terminals = new SymbolsList(configuration.SymbolFactory);
-            NonTerminals = new SymbolsList(configuration.SymbolFactory);
+            Terminals = new GrammarSymbolsSet(configuration.SymbolFactory);
+            NonTerminals = new GrammarSymbolsSet(configuration.SymbolFactory);
         }
 
         #region Internal
@@ -71,8 +70,8 @@ namespace Nt.Syntax.Structures
         #region Public
 
         public char EscapeCharacter { get; private set; } = '\'';
-        public SymbolsList Terminals { get; }
-        public SymbolsList NonTerminals { get; }
+        public GrammarSymbolsSet Terminals { get; }
+        public GrammarSymbolsSet NonTerminals { get; }
         public NonTerminal? Axiom { get; internal set; } = null;
         public RulesSet Rules { get; } = [];
         public RegexSet RegularExpressions { get; } = [];

--- a/Domain/Structures/Grammar.cs
+++ b/Domain/Structures/Grammar.cs
@@ -2,6 +2,7 @@
 using Nt.Parser.Structures;
 using Nt.Parser.Symbols;
 using Nt.Syntax.Exceptions;
+using Nt.Syntax.Exportation;
 
 namespace Nt.Syntax.Structures
 {
@@ -215,25 +216,7 @@ namespace Nt.Syntax.Structures
         /// <returns>A string representing this grammar</returns>
         public override string ToString()
         {
-            var sb = new StringBuilder();
-
-            sb.Append("Terminals: ").Append(Terminals.ToString()).Append('\n');
-            sb.Append("Non terminals: ").Append(NonTerminals.ToString()).Append('\n');
-            if (Axiom != null) sb.Append("Axiom: ").Append(Axiom.Name).Append('\n');
-
-            if (Rules.Count > 0) sb.Append("\nRules\n");
-            foreach (Rule rule in Rules)
-            {
-                sb.Append("  ").Append(rule.ToString()).Append('\n');
-            }
-
-            if (RegularExpressions.Count > 0) sb.Append("\nRegular expressions\n");
-            foreach (RegularExpression regularExpression in RegularExpressions)
-            {
-                sb.Append("  ").Append(regularExpression.ToString()).Append('\n');
-            }
-
-            return sb.ToString();
+           return this.ToString(ExportationMode.Original);
         }
 
         #endregion

--- a/Domain/Structures/Grammar.cs
+++ b/Domain/Structures/Grammar.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using Nt.Parser.Structures;
+﻿using Nt.Parser.Structures;
 using Nt.Parser.Symbols;
 using Nt.Syntax.Exceptions;
 using Nt.Syntax.Exportation;
@@ -74,140 +73,17 @@ namespace Nt.Syntax.Structures
         public char EscapeCharacter { get; private set; } = '\'';
         public SymbolsList Terminals { get; }
         public SymbolsList NonTerminals { get; }
-        public NonTerminal? Axiom { get; private set; } = null;
+        public NonTerminal? Axiom { get; internal set; } = null;
         public RulesSet Rules { get; } = [];
-        public RegExpSet RegularExpressions { get; } = [];
+        public RegexSet RegularExpressions { get; } = [];
 
         /// <summary>
         /// Sets the character used to escape special characters in parsing or formatting operations.
         /// </summary>
         /// <param name="c">The character to use as the escape character.</param>
-        public void SetEscapeCharacter(char c)
+        public void SetEscapeChar(char c)
         {
             EscapeCharacter = c;
-        }
-
-        /// <summary>
-        /// Adds a new terminal to the terminals list of this grammar
-        /// </summary>
-        /// <param name="name">Name of the terminal to add</param>
-        /// <exception cref="RegisteredTerminalException">The terminal may already exists in the list of terminals</exception>
-        /// <exception cref="RegisteredNonTerminalException">The non terminal may already exists in the list of non terminals</exception>
-        public ISymbol AddTerminal(string name)
-        {
-            if (Terminals.Contains(name)) throw new RegisteredTerminalException(name);
-            if (NonTerminals.Contains(name)) throw new RegisteredNonTerminalException(name);
-            return Terminals.Add(name);
-        }
-
-        /// <summary>
-        /// Adds a new non terminal to the non terminals list of this grammar
-        /// </summary>
-        /// <param name="name">Name of the non terminal to add</param>
-        /// <exception cref="RegisteredNonTerminalException">The non terminal may already exists in the list of non terminals</exception>
-        /// <exception cref="RegisteredNonTerminalException">The non terminal may already exists in the list of non terminals</exception>
-        public ISymbol AddNonTerminal(string name)
-        {
-            if (NonTerminals.Contains(name)) throw new RegisteredNonTerminalException(name);
-            if (Terminals.Contains(name)) throw new RegisteredTerminalException(name);
-            return NonTerminals.Add(name);
-        }
-
-        /// <summary>
-        /// Removes the specified terminal symbol from the collection of terminals.
-        /// </summary>
-        /// <param name="symbol">The terminal symbol to remove from the collection. Cannot be null.</param>
-        /// <exception cref="KeyNotFoundException">Thrown when symbol does not exists in collection of terminals.</exception>
-        public void RemoveTerminal(ISymbol symbol)
-        {
-            Terminals.Remove(symbol);
-        }
-
-        /// <summary>
-        /// Removes the specified non-terminal symbol from the collection of non-terminals.
-        /// </summary>
-        /// <param name="symbol">The non-terminal symbol to remove from the collection. Cannot be null.</param>
-        /// <exception cref="KeyNotFoundException">Thrown when symbol does not exists in collection of non-terminals.</exception>"
-        public void RemoveNonTerminal(ISymbol symbol)
-        {
-            NonTerminals.Remove(symbol);
-        }
-
-        /// <summary>
-        /// Sets the axiom of this grammar
-        /// </summary>
-        /// <param name="name">Non terminal to set for axiom</param>
-        /// <exception cref="UnregisteredNonTerminalException">The axiom might not exist in the non terminals list of this grammar</exception>
-        public void SetAxiom(NonTerminal token)
-        {
-            if (!NonTerminals.Contains(token.Name)) throw new UnregisteredNonTerminalException(token.Name, token.Line);
-            Axiom = token;
-        }
-
-        /// <summary>
-        /// Adds a new grammar rule for the specified non-terminal symbol at the given source line.
-        /// </summary>
-        /// <param name="nonTerminal">The non-terminal symbol for which the rule is to be created. Must be declared in the grammar.</param>
-        /// <returns>A Rule instance representing the newly added grammar rule.</returns>
-        /// <exception cref="UnregisteredNonTerminalException">Thrown if the specified non-terminal symbol has not been declared in the grammar.</exception>
-        public Rule AddRule(NonTerminal nt)
-        {
-            var rule = new Rule(this);
-            Rules.Add(rule);
-            rule.SetToken(nt);
-            return rule;
-        }
-
-        /// <summary>
-        /// Add a rule to the collection of rules of this grammar
-        /// </summary>
-        /// <param name="rule">Rule to add</param>
-        public void AddRule(Rule rule)
-        {
-            Rules.Add(rule);
-        }
-
-        /// <summary>
-        /// Adds a new regular expression associated with the specified non-terminal symbol at the given source line.
-        /// </summary>
-        /// <param name="nonTerminal">The non-terminal symbol to associate with the new regular expression. Must be declared prior to calling this method.</param>
-        /// <returns>A RegularExpression instance representing the newly added regular expression.</returns>
-        /// <exception cref="UnregisteredNonTerminalException">Thrown if the specified non-terminal symbol has not been declared.</exception>
-        public RegularExpression AddRegex(NonTerminal nt)
-        {
-            var regex = new RegularExpression(this);
-            RegularExpressions.Add(regex);
-            regex.SetToken(nt);
-            return regex;
-        }
-
-        /// <summary>
-        /// Add a regular expression to the collection of regular expressions of this grammar
-        /// </summary>
-        /// <param name="regex">Regular expression to add</param>
-        public void AddRegex(RegularExpression regex)
-        {
-            RegularExpressions.Add(regex);
-        }
-
-        /// <summary>
-        /// Removes the specified rule from the collection of rules.
-        /// </summary>
-        /// <param name="rule">The rule to remove from the collection.</param>
-        /// <exception cref="RuleNotFoundException">The rule is not part of the grammar</exception>
-        public void Remove(Rule rule)
-        {
-            Rules.Remove(rule);
-        }
-
-        /// <summary>
-        /// Removes the specified regular expression from the collection.
-        /// </summary>
-        /// <param name="regex">The regular expression to remove from the collection. Cannot be null.</param>
-        /// <exception cref="RegexNotFoundException">The regular expression is not part of the grammar</exception>
-        public void Remove(RegularExpression regex)
-        {
-            RegularExpressions.Remove(regex);
         }
 
         /// <summary>

--- a/Domain/Structures/GrammarSymbolsSet.cs
+++ b/Domain/Structures/GrammarSymbolsSet.cs
@@ -1,0 +1,82 @@
+﻿using Nt.Parser.Structures;
+using Nt.Parser.Symbols;
+
+namespace Nt.Syntax.Structures
+{
+    public class GrammarSymbolsSet(ISymbolFactory factory)
+    {
+        private SymbolsList Symbols { get; } = new(factory);
+
+        public int Count { get => Symbols.GetCount(); }
+
+        internal void Add(string name)
+        {
+            Symbols.Add(name);
+        }
+
+        internal void Remove(string name)
+        {
+            Symbols.Remove(name);
+        }
+
+        /// <summary>
+        /// Get a list of symbols in this set
+        /// </summary>
+        /// <returns>List of symbol contained in this set</returns>
+        public List<ISymbol> GetSymbols()
+        {
+            return Symbols.GetSymbols();
+        }
+
+        /// <summary>
+        /// Determine whether a symbol with the specified name exists in the collection.
+        /// </summary>
+        /// <param name="name">The name of the symbol to locate</param>
+        /// <returns>true if a symbol with the specified name exists in the collection; otherwise, false.</returns>
+        public bool Contains(string name)
+        {
+            return Symbols.Contains(name);
+        }
+
+        /// <summary>
+        /// Get the index of a symbol in the collection.
+        /// </summary>
+        /// <param name="name">Name of the symbol to locate</param>
+        /// <returns>The index of the symbol with the specified name</returns>
+        /// <exception cref="KeyNotFoundException">Thrown when a symbol with the specified name does not exist in the collection</exception>
+        public int IndexOf(string name)
+        {
+            return Symbols.IndexOf(name);
+        }
+
+        /// <summary>
+        /// Retrieve the symbol associated with the specified name.
+        /// </summary>
+        /// <param name="name">Name of the symbol to retrieve.</param>
+        /// <returns>The symbol associated with the specified name.</returns>
+        /// <exception cref="KeyNotFoundException">Thrown when a symbol with the specified name does not exist in the collection</exception>
+        public ISymbol Get(string name)
+        {
+            return Symbols.Get(name);
+        }
+
+        /// <summary>
+        /// Retrieves the symbol at the specified index in the collection.
+        /// </summary>
+        /// <param name="index">The zero-based index of the symbol to retrieve.</param>
+        /// <returns>The symbol located at the specified index.</returns>
+        public ISymbol Get(int index)
+        {
+            return Symbols.Get(index);
+        }
+
+        /// <summary>
+        /// Get a string representing a list of all symbols in the collection.
+        /// </summary>
+        /// <returns>A string that represents this instance.</returns>
+        public override string ToString()
+        {
+            return Symbols.ToString();
+        }
+    }
+}

--- a/Domain/Structures/RegExpSet.cs
+++ b/Domain/Structures/RegExpSet.cs
@@ -1,4 +1,5 @@
 ﻿using Nt.Syntax.Exceptions;
+using Nt.Syntax.Exportation;
 using System.Collections;
 using System.Text;
 
@@ -6,36 +7,7 @@ namespace Nt.Syntax.Structures
 {
     public class RegExpSet() : IEnumerable<RegularExpression>
     {
-        #region Private
-
-        private HashSet<RegularExpression> Regexs { get; } = [];
-
-        #endregion
-
-        #region Internal
-
-        /// <summary>
-        /// Adds the specified regular expression to the collection of rules.
-        /// </summary>
-        /// <param name="rule">The regular expression to add to the collection.</param>
-        internal void Add(RegularExpression regex)
-        {
-            Regexs.Add(regex);
-        }
-
-        /// <summary>
-        /// Removes the specified regular expression from the collection.
-        /// </summary>
-        /// <param name="regex">The regular expression to remove from the collection. Cannot be null.</param>
-        /// <exception cref="RegexNotFoundException">Thrown if the specified regular expression is not found in the collection.</exception>
-        internal void Remove(RegularExpression regex)
-        {
-            if (!Regexs.Remove(regex)) throw new RegexNotFoundException(regex, $"Regular expression {regex} not found in collection of regular expressions");
-        }
-
-        #endregion
-
-        #region Public
+        #region Implementation of IEnumerable
 
         public int Count { get => Regexs.Count; }
 
@@ -51,15 +23,54 @@ namespace Nt.Syntax.Structures
             return GetEnumerator();
         }
 
+        #endregion
+
+        #region Private
+
+        private HashSet<RegularExpression> Regexs { get; } = [];
+
+        #endregion
+
+        #region Public
+
+        /// <summary>
+        /// Add the specified regular expression to the collection of rules.
+        /// </summary>
+        /// <param name="rule">The regular expression to add to the collection.</param>
+        public void Add(RegularExpression regex)
+        {
+            Regexs.Add(regex);
+        }
+
+        /// <summary>
+        /// Adds the elements of the specified collection of regular expressions to the current collection.
+        /// </summary>
+        /// <param name="regexs">The collection of <see cref="RegularExpression"/> objects to add.</param>
+        public void AddRange(IEnumerable<RegularExpression> regexs)
+        {
+            foreach (var regex in regexs)
+            {
+                Add(regex);
+            }
+        }
+
+        /// <summary>
+        /// Remove the specified regular expression from the collection.
+        /// </summary>
+        /// <param name="regex">The regular expression to remove from the collection. Cannot be null.</param>
+        /// <exception cref="RegexNotFoundException">Thrown if the specified regular expression is not found in the collection.</exception>
+        public void Remove(RegularExpression regex)
+        {
+            if (!Regexs.Remove(regex)) throw new RegexNotFoundException(regex, $"Regular expression {regex} not found in collection of regular expressions");
+        }
+
         /// <summary>
         /// Returns a string that represents the collection in a comma-separated list enclosed in braces.
         /// </summary>
         /// <returns>A string containing the elements of the collection, separated by commas and enclosed in curly bracets.</returns>
         public override string ToString()
         {
-            var sb = new StringBuilder();
-            sb.Append('{').Append(string.Join(",", this)).Append('}');
-            return sb.ToString();
+            return this.ToString(ExportationMode.Original);
         }
 
         #endregion

--- a/Domain/Structures/RegexSet.cs
+++ b/Domain/Structures/RegexSet.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Nt.Syntax.Structures
 {
-    public class RegExpSet() : IEnumerable<RegularExpression>
+    public class RegexSet() : IEnumerable<RegularExpression>
     {
         #region Implementation of IEnumerable
 
@@ -37,7 +37,7 @@ namespace Nt.Syntax.Structures
         /// Add the specified regular expression to the collection of rules.
         /// </summary>
         /// <param name="rule">The regular expression to add to the collection.</param>
-        public void Add(RegularExpression regex)
+        internal void Add(RegularExpression regex)
         {
             Regexs.Add(regex);
         }
@@ -46,7 +46,7 @@ namespace Nt.Syntax.Structures
         /// Adds the elements of the specified collection of regular expressions to the current collection.
         /// </summary>
         /// <param name="regexs">The collection of <see cref="RegularExpression"/> objects to add.</param>
-        public void AddRange(IEnumerable<RegularExpression> regexs)
+        internal void AddRange(IEnumerable<RegularExpression> regexs)
         {
             foreach (var regex in regexs)
             {
@@ -59,7 +59,7 @@ namespace Nt.Syntax.Structures
         /// </summary>
         /// <param name="regex">The regular expression to remove from the collection. Cannot be null.</param>
         /// <exception cref="RegexNotFoundException">Thrown if the specified regular expression is not found in the collection.</exception>
-        public void Remove(RegularExpression regex)
+        internal void Remove(RegularExpression regex)
         {
             if (!Regexs.Remove(regex)) throw new RegexNotFoundException(regex, $"Regular expression {regex} not found in collection of regular expressions");
         }

--- a/Domain/Structures/RegexSet.cs
+++ b/Domain/Structures/RegexSet.cs
@@ -65,6 +65,18 @@ namespace Nt.Syntax.Structures
         }
 
         /// <summary>
+        /// Get a regular expression at the specified index
+        /// </summary>
+        /// <param name="index">Index of the regular expression</param>
+        /// <returns>The regular expression at the specified index</returns>
+        /// <exception cref="IndexOutOfRangeException">Thrown if the index is out of range</exception>
+        public RegularExpression Get(int index)
+        {
+            if (index < 0 || index >= Regexs.Count) throw new IndexOutOfRangeException($"Index {index} is out of range for collection of regular expressions with count {Regexs.Count}");
+            return Regexs.ElementAt(index);
+        }
+
+        /// <summary>
         /// Returns a string that represents the collection in a comma-separated list enclosed in braces.
         /// </summary>
         /// <returns>A string containing the elements of the collection, separated by commas and enclosed in curly bracets.</returns>

--- a/Domain/Structures/RegularExpression.cs
+++ b/Domain/Structures/RegularExpression.cs
@@ -5,33 +5,14 @@ namespace Nt.Syntax.Structures
 {
     public class RegularExpression(Grammar grammar)
     {
-        public NonTerminal? Token { get; private set; }
-        public string Pattern { get; private set; } = "";
-
-        /// <summary>
-        /// Sets the token of this regular expression to the specified non-terminal symbol.
-        /// </summary>
-        /// <param name="nt">The non-terminal symbol to assign as the current token. The non-terminal must be declared in the grammar;</param>
-        /// <exception cref="UnregisteredNonTerminalException">Thrown if the specified non-terminal symbol is not declared in the grammar.</exception>
-        public void SetToken(NonTerminal nt)
-        {
-            if (!grammar.NonTerminals.Contains(nt.Name)) throw new UnregisteredNonTerminalException(nt.Name, nt.Line);
-            Token = nt;
-        }
-
-        /// <summary>
-        /// Appends the specified symbols to the current pattern.
-        /// </summary>
-        /// <param name="symbols">A string containing the symbols to add to the pattern. Cannot be null.</param>
-        public void AddSymbols(string symbols)
-        {
-            Pattern += symbols;
-        }
+        internal Grammar Grammar { get; } = grammar;
+        public NonTerminal? Token { get; internal set; }
+        public string Pattern { get; internal set; } = "";
 
         /// <summary>
         /// Gets a string representation of this regular expression
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A string representing the regular expression</returns>
         public override string ToString()
         {
             var sb = new StringBuilder();

--- a/Domain/Structures/Rule.cs
+++ b/Domain/Structures/Rule.cs
@@ -19,7 +19,7 @@ namespace Nt.Syntax.Structures
         /// <summary>
         /// List of tokens that represent derivation
         /// </summary>
-        public Derivation Derivation { get; } = new();
+        public RuleDerivation Derivation { get; } = new();
 
         /// <summary>
         /// Gets a string representing this rule

--- a/Domain/Structures/Rule.cs
+++ b/Domain/Structures/Rule.cs
@@ -11,96 +11,15 @@ namespace Nt.Syntax.Structures
     /// <param name="nonterminals">Non terminals tokens of the grammar</param>
     public class Rule(Grammar grammar)
     {
+        internal Grammar Grammar { get; } = grammar;
         /// <summary>
         /// Token that would derive into derivation
         /// </summary>
-        public NonTerminal? Token { get; private set; }
+        public NonTerminal? Token { get; internal set; }
         /// <summary>
         /// List of tokens that represent derivation
         /// </summary>
         public Derivation Derivation { get; } = new();
-
-        /// <summary>
-        /// Sets the token of this rule to the specified non-terminal symbol.
-        /// </summary>
-        /// <param name="nt">The non-terminal symbol to assign as the current token. The non-terminal must be declared in the grammar;</param>
-        /// <exception cref="UnregisteredNonTerminalException">Thrown if the specified non-terminal symbol is not declared in the grammar.</exception>
-        public void SetToken(NonTerminal nt)
-        {
-            if (!grammar.NonTerminals.Contains(nt.Name)) throw new UnregisteredNonTerminalException(nt.Name, nt.Line);
-            Token = nt;
-        }
-
-        /// <summary>
-        /// Adds a derivation token to the current grammar derivation sequence.
-        /// </summary>
-        /// <param name="token">The token to add to the derivation sequence.</param>
-        /// <exception cref="UnknownSymbolException">Thrown if the token's symbol is not declared in the grammar.</exception>
-        public void Add(GrammarToken token)
-        {
-            if (!grammar.Terminals.Contains(token.Name) && !grammar.NonTerminals.Contains(token.Name))
-                throw new UnknownSymbolException(token.Name, token.Line);
-            Derivation.Add(token);
-        }
-        /// <summary>
-        /// Adds a terminal token to end of derivation
-        /// </summary>
-        /// <param name="symbol">Symbol of the token</param>
-        /// <param name="line">Line the token have been parsed</param>
-        /// <exception cref="UnregisteredTerminalException">Thrown if the terminal is not declared in the grammar</exception>"
-        public void Add(Terminal t)
-        {
-            if (!grammar.Terminals.Contains(t.Name)) throw new UnregisteredTerminalException(t.Name, t.Line);
-            Derivation.Add(t);
-        }
-        /// <summary>
-        /// Adds a non terminal token to end of derivation
-        /// </summary>
-        /// <param name="symbol">Symbol of the token</param>
-        /// <param name="line">Line the token have been parsed</param>
-        /// <exception cref="UnregisteredNonTerminalException">Thrown if the non terminal is not declared in the grammar</exception>
-        public void Add(NonTerminal nt)
-        {
-            if (!grammar.NonTerminals.Contains(nt.Name)) throw new UnregisteredNonTerminalException(nt.Name, nt.Line);
-            Derivation.Add(nt);
-        }
-
-        /// <summary>
-        /// Inserts a derivation token at the specified position in the derivation sequence.
-        /// </summary>
-        /// <param name="position">The index at which the token should be inserted.</param>
-        /// <param name="token">The derivation token to insert.</param>
-        /// <exception cref="UnknownSymbolException">Thrown if the token's symbol is not declared in the grammar.</exception>
-        public void Insert(int position, GrammarToken token)
-        {
-            if (!grammar.Terminals.Contains(token.Name) && !grammar.NonTerminals.Contains(token.Name))
-                throw new UnknownSymbolException(token.Name, token.Line);
-            Derivation.Insert(position, token);
-        }
-        /// <summary>
-        /// Inserts a terminal token at specified position in derivation
-        /// </summary>
-        /// <param name="position">Position for inserting the terminal</param>
-        /// <param name="symbol">Symbol of the token</param>
-        /// <param name="line">Line of the new terminal</param>
-        /// <exception cref="UnregisteredTerminalException">Thrown if the terminal is not declared in the grammar</exception>
-        public void Insert(int position, Terminal t)
-        {
-            if (!grammar.Terminals.Contains(t.Name)) throw new UnregisteredTerminalException(t.Name, t.Line);
-            Derivation.Insert(position, t);
-        }
-        /// <summary>
-        /// Inserts a non terminal token at specified position in derivation
-        /// </summary>
-        /// <param name="position">Position for inserting the non terminal</param>
-        /// <param name="symbol">Symbol of the token</param>
-        /// <param name="line">Line of the new non terminal</param>
-        /// <exception cref="UnregisteredNonTerminalException">Thrown if the non terminal is not declared in the grammar</exception>"
-        public void Insert(int position, NonTerminal nt)
-        {
-            if (!grammar.NonTerminals.Contains(nt.Name)) throw new UnregisteredNonTerminalException(nt.Name, nt.Line);
-            Derivation.Insert(position, nt);
-        }
 
         /// <summary>
         /// Gets a string representing this rule

--- a/Domain/Structures/RuleDerivation.cs
+++ b/Domain/Structures/RuleDerivation.cs
@@ -57,7 +57,7 @@ namespace Nt.Syntax.Structures
         /// Adds the specified grammar token to the collection.
         /// </summary>
         /// <param name="token">The grammar token to add to the collection.</param>
-        public void Add(GrammarToken token)
+        internal void Add(GrammarToken token)
         {
             Tokens.Add(token);
         }
@@ -67,7 +67,7 @@ namespace Nt.Syntax.Structures
         /// </summary>
         /// <param name="position">The zero-based index at which the token should be inserted.</param>
         /// <param name="token">The token to insert into the collection.</param>
-        public void Insert(int position, GrammarToken token)
+        internal void Insert(int position, GrammarToken token)
         {
             Tokens.Insert(position, token);
         }

--- a/Domain/Structures/RuleDerivation.cs
+++ b/Domain/Structures/RuleDerivation.cs
@@ -9,7 +9,7 @@ namespace Nt.Syntax.Structures
     /// </summary>
     /// <param name="terminals">Terminal tokens of the rule</param>
     /// <param name="nonterminals">Non terminal tokens of the rule</param>
-    public class Derivation : IReadOnlyList<GrammarToken>
+    public class RuleDerivation : IReadOnlyList<GrammarToken>
     {
         #region Private
 

--- a/Domain/Structures/RulesSet.cs
+++ b/Domain/Structures/RulesSet.cs
@@ -64,6 +64,18 @@ namespace Nt.Syntax.Structures
         }
 
         /// <summary>
+        /// Get a rule at a specified index
+        /// </summary>
+        /// <param name="index">Index of the rule to get</param>
+        /// <returns>The rule at the specified index</returns>
+        /// <exception cref="IndexOutOfRangeException">Thrown if the index is out of range</exception>
+        public Rule Get(int index)
+        {
+            if (index < 0 || index >= Rules.Count) throw new IndexOutOfRangeException($"Index {index} is out of range for collection of rules with count {Rules.Count}");
+            return Rules.ElementAt(index);
+        }
+
+        /// <summary>
         /// Returns a string that represents the collection in a comma-separated list enclosed in braces.
         /// </summary>
         /// <returns>A string containing the elements of the collection, separated by commas and enclosed in curly braces.</returns>

--- a/Domain/Structures/RulesSet.cs
+++ b/Domain/Structures/RulesSet.cs
@@ -1,41 +1,12 @@
 ﻿using Nt.Syntax.Exceptions;
+using Nt.Syntax.Exportation;
 using System.Collections;
-using System.Text;
 
 namespace Nt.Syntax.Structures
 {
     public class RulesSet() : IEnumerable<Rule>
     {
-        #region Private
-
-        private HashSet<Rule> Rules { get; } = [];
-
-        #endregion
-
-        #region Internal
-
-        /// <summary>
-        /// Adds the specified rule to the collection of rules.
-        /// </summary>
-        /// <param name="rule">The rule to add to the collection.</param>
-        internal void Add(Rule rule)
-        {
-            Rules.Add(rule);
-        }
-
-        /// <summary>
-        /// Removes the specified rule from the collection.
-        /// </summary>
-        /// <param name="rule">The rule to remove from the collection. Cannot be null.</param>
-        /// <exception cref="RuleNotFoundException">Thrown if the specified rule does not exist in the collection.</exception>
-        internal void Remove(Rule rule)
-        {
-            if (!Rules.Remove(rule)) throw new RuleNotFoundException(rule, $"Rule {rule} not found in collection of rules");
-        }
-
-        #endregion
-
-        #region Public
+        #region Implementation of IEnumerable
 
         public int Count { get => Rules.Count; }
 
@@ -51,15 +22,54 @@ namespace Nt.Syntax.Structures
             return GetEnumerator();
         }
 
+        #endregion
+
+        #region Private
+
+        private HashSet<Rule> Rules { get; } = [];
+
+        #endregion
+
+        #region Public
+
+        /// <summary>
+        /// Add the specified rule to the collection of rules.
+        /// </summary>
+        /// <param name="rule">The rule to add to the collection.</param>
+        public void Add(Rule rule)
+        {
+            Rules.Add(rule);
+        }
+
+        /// <summary>
+        /// Add a range of rules to the collection of rules.
+        /// </summary>
+        /// <param name="rules">The collection of <see cref="Rule"> objects to add</param>
+        public void AddRange(IEnumerable<Rule> rules)
+        {
+            foreach (var rule in rules)
+            {
+                Add(rule);
+            }
+        }
+
+        /// <summary>
+        /// Remove the specified rule from the collection.
+        /// </summary>
+        /// <param name="rule">The rule to remove from the collection. Cannot be null.</param>
+        /// <exception cref="RuleNotFoundException">Thrown if the specified rule does not exist in the collection.</exception>
+        public void Remove(Rule rule)
+        {
+            if (!Rules.Remove(rule)) throw new RuleNotFoundException(rule, $"Rule {rule} not found in collection of rules");
+        }
+
         /// <summary>
         /// Returns a string that represents the collection in a comma-separated list enclosed in braces.
         /// </summary>
         /// <returns>A string containing the elements of the collection, separated by commas and enclosed in curly braces.</returns>
         public override string ToString()
         {
-            var sb = new StringBuilder();
-            sb.Append('{').Append(string.Join(",", this)).Append('}');
-            return sb.ToString();
+            return this.ToString(ExportationMode.Original); 
         }
 
         #endregion

--- a/Domain/Structures/RulesSet.cs
+++ b/Domain/Structures/RulesSet.cs
@@ -36,7 +36,7 @@ namespace Nt.Syntax.Structures
         /// Add the specified rule to the collection of rules.
         /// </summary>
         /// <param name="rule">The rule to add to the collection.</param>
-        public void Add(Rule rule)
+        internal void Add(Rule rule)
         {
             Rules.Add(rule);
         }
@@ -45,7 +45,7 @@ namespace Nt.Syntax.Structures
         /// Add a range of rules to the collection of rules.
         /// </summary>
         /// <param name="rules">The collection of <see cref="Rule"> objects to add</param>
-        public void AddRange(IEnumerable<Rule> rules)
+        internal void AddRange(IEnumerable<Rule> rules)
         {
             foreach (var rule in rules)
             {
@@ -58,7 +58,7 @@ namespace Nt.Syntax.Structures
         /// </summary>
         /// <param name="rule">The rule to remove from the collection. Cannot be null.</param>
         /// <exception cref="RuleNotFoundException">Thrown if the specified rule does not exist in the collection.</exception>
-        public void Remove(Rule rule)
+        internal void Remove(Rule rule)
         {
             if (!Rules.Remove(rule)) throw new RuleNotFoundException(rule, $"Rule {rule} not found in collection of rules");
         }

--- a/Domain/Structures/Terminal.cs
+++ b/Domain/Structures/Terminal.cs
@@ -1,5 +1,4 @@
-﻿using Nt.Parser.Structures;
-using Nt.Parser.Symbols;
+﻿using Nt.Parser.Symbols;
 
 namespace Nt.Syntax.Structures
 {

--- a/Domain/SyntaxParser.cs
+++ b/Domain/SyntaxParser.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text;
 using Nt.Automaton.States;
 using Nt.Parser;
-using Nt.Parser.Symbols;
 using Nt.Syntax.Actions;
 
 using StateAutomaton = Nt.Automaton.Automatons.StateAutomaton<string>;
@@ -14,27 +13,6 @@ using Nt.Syntax.Exceptions;
 
 namespace Nt.Syntax
 {
-
-    public class SyntaxParserConfig
-    {
-        public ISymbolFactory SymbolFactory { get; private set; } = new SymbolFactory();
-
-        public void SetSymbolFactory(ISymbolFactory factory)
-        {
-            SymbolFactory = factory;
-        }
-
-        private static SyntaxParserConfig? _instance = null;
-
-        public static SyntaxParserConfig GetInstance()
-        {
-            if (_instance == null)
-            {
-                _instance = new SyntaxParserConfig();
-            }
-            return _instance;
-        }
-    }
 
     public class SyntaxParser
     {

--- a/Domain/SyntaxParser.cs
+++ b/Domain/SyntaxParser.cs
@@ -291,7 +291,7 @@ namespace Nt.Syntax
             }
             catch (InternalException ex)
             {
-                throw ex;
+                throw new Exception("An error occurred while trying to pre-parse the string.", ex);
             }
             catch
             {
@@ -326,7 +326,7 @@ namespace Nt.Syntax
             }
             catch (InternalException ex)
             {
-                throw ex;
+                throw new Exception("An error occurred while trying to parse the string.", ex);
             }
             catch
             {
@@ -348,7 +348,7 @@ namespace Nt.Syntax
             }
             catch (InternalException ex)
             {
-                throw ex;
+                throw new Exception($"An error occurred while trying to parse the file at {path}.", ex);
             }
             catch
             {

--- a/Domain/SyntaxParser.cs
+++ b/Domain/SyntaxParser.cs
@@ -289,9 +289,9 @@ namespace Nt.Syntax
                 Nt.Parser.SymbolsParser parser = new(configuration.SymbolFactory, [' ', '\0', '\n', '\t'], ["import", "IMPORT", "addtopath", "ADDTOPATH", "escape", "ESCAPE", ";"]);
                 return PreParseString(content, parser);
             }
-            catch (InternalException ex)
+            catch (InternalException)
             {
-                throw new Exception("An error occurred while trying to pre-parse the string.", ex);
+                throw;
             }
             catch
             {
@@ -324,9 +324,9 @@ namespace Nt.Syntax
 
                 return Grammar;
             }
-            catch (InternalException ex)
+            catch (InternalException)
             {
-                throw new Exception("An error occurred while trying to parse the string.", ex);
+                throw;
             }
             catch
             {
@@ -346,9 +346,9 @@ namespace Nt.Syntax
                 string content = File.ReadAllText(path);
                 return ParseString(content);
             }
-            catch (InternalException ex)
+            catch (InternalException)
             {
-                throw new Exception($"An error occurred while trying to parse the file at {path}.", ex);
+                throw;
             }
             catch
             {

--- a/Domain/SyntaxParserConfig.cs
+++ b/Domain/SyntaxParserConfig.cs
@@ -1,0 +1,26 @@
+﻿using Nt.Parser.Symbols;
+
+
+namespace Nt.Syntax
+{
+    public class SyntaxParserConfig
+    {
+        public ISymbolFactory SymbolFactory { get; private set; } = new SymbolFactory();
+
+        public void SetSymbolFactory(ISymbolFactory factory)
+        {
+            SymbolFactory = factory;
+        }
+
+        private static SyntaxParserConfig? _instance = null;
+
+        public static SyntaxParserConfig GetInstance()
+        {
+            if (_instance == null)
+            {
+                _instance = new SyntaxParserConfig();
+            }
+            return _instance;
+        }
+    }
+}

--- a/Nt.SyntaxParser.sln
+++ b/Nt.SyntaxParser.sln
@@ -20,6 +20,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Doc", "Doc", "{14004574-271D-4BE4-A955-501003C985E7}"
 	ProjectSection(SolutionItems) = preProject
 		Doc\Exceptions.md = Doc\Exceptions.md
+		Doc\Exportation.md = Doc\Exportation.md
 		Doc\Grammar.md = Doc\Grammar.md
 		README.md = README.md
 	EndProjectSection

--- a/Nt.SyntaxParser.sln
+++ b/Nt.SyntaxParser.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution files", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
 		nuget.config = nuget.config
 		README.md = README.md
 	EndProjectSection

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # SyntaxParser
 
+- [Introduction](#introduction)
+- [Grammar structure](#grammar-structure)
+- [Grammar file](#grammar-file)
+- [Using the syntax parser](#using-the-syntax-parser)
+- [Export the grammar](#export-the-grammar)
+- [Exceptions](#exceptions)
+
 ## Introduction
 This project takes a grammar file as input and parses into a grammar structure.
 It aims to be used when creating new software languages.
@@ -80,13 +87,6 @@ Rules:
 ```
 
 There are different modes of exporting a grammar, please read the [exportation documentation](Doc/Exportation.md) which describes how to export a grammar and contains more informations about methods of exporting it.
-
-## Escape character
-The escape character '\\' is a special character that allows any symbol following it to be parsed in the continuity of the token being currently parsed instead of creating a new one. The escape character is used when you need to include symbols or separators in a token.
-
-For example, consider the two following cases:
-1. Consider a parser with `+` defined as a symbol. Then "a+b" will be parsed as 3 tokens : 'a', '+' and 'b'. With the escape character, "a\\+b" is parsed as a unique symbol "a+b".
-2. Consider a parser with "\_" defined as a separator. Then "a_b" will be parsed as 3 tokens: 'a', '\_' and 'b'. But "a\\\_b" is parsed as the unique symbol "a\_b".
 
 ## Exceptions
 This project contains several custom exceptions to handle errors that may occur during the parsing of grammar files or input strings. See a list of exceptions [here](Doc/Exceptions.md).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,40 @@ Also parsing a grammar always applies the pre-parser on it, it's also possible t
 > In this case, the custom symbol must extend the `ISymbol` interface and you have to provide a custom symbol factory implementing the `ISymbolFactory`.
 > You can then set this factory as default factory for parsing with `SyntaxParserConfig.GetInstance().SetSymbolFactory(new_factory)`.
 
+
+## Export the grammar
+The grammar is meant to get different transformation in your code. After that, you may need to get the grammar displayed or written back in a file.
+This is why this project supports exporting grammars.
+
+For example, you can display the grammar using the method `ToString()`. This method will display the content of the grammar in a user-friendly way.
+
+Grammar file:
+```
+TERMINALS: a, b;
+NON TERMINALS: S, D;
+AXIOM: S
+RULES: S -> D, D -> a;
+```
+
+The grammar after exportation:
+```
+Terminals:
+- a
+- b
+
+Non Terminals:
+- S
+- D
+
+Axiom: S
+
+Rules:
+- S -> D
+- D -> a b
+```
+
+There are different modes of exporting a grammar, please read the [exportation documentation](Doc/Exportation.md) which describes how to export a grammar and contains more informations about methods of exporting it.
+
 ## Escape character
 The escape character '\\' is a special character that allows any symbol following it to be parsed in the continuity of the token being currently parsed instead of creating a new one. The escape character is used when you need to include symbols or separators in a token.
 

--- a/Tests/Actions/AddNewRegExActionTest.cs
+++ b/Tests/Actions/AddNewRegExActionTest.cs
@@ -5,6 +5,7 @@ using Nt.Syntax.Automaton;
 using Nt.Parser.Symbols;
 using Nt.Parser.Structures;
 using Nt.Syntax.Exceptions;
+using Nt.Syntax.Builders;
 
 namespace Nt.Tests.Syntax.Actions
 {
@@ -15,8 +16,7 @@ namespace Nt.Tests.Syntax.Actions
         [Fact]
         public void AddNewRegExAction_test1()
         {
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("A");
+            var grammar = new Grammar().GetBuilder().AddNonTerminal("A").Build();
 
             var symbols = new SymbolsList(SymbolFactory, ["A"]);
             var context = new AutomatonContext();
@@ -31,8 +31,7 @@ namespace Nt.Tests.Syntax.Actions
         [Fact]
         public void AddNewRegexAction_test2()
         {
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("A");
+            var grammar = new Grammar().GetBuilder().AddNonTerminal("A").Build();
 
             var symbols = new SymbolsList(SymbolFactory, ["B"]);
             var context = new AutomatonContext();

--- a/Tests/Actions/AddNewRuleActionTest.cs
+++ b/Tests/Actions/AddNewRuleActionTest.cs
@@ -4,6 +4,7 @@ using Nt.Syntax.Automaton;
 using Nt.Parser.Symbols;
 using Nt.Parser.Structures;
 using Nt.Syntax.Exceptions;
+using Nt.Syntax.Builders;
 
 namespace Nt.Tests.Syntax.Actions
 {
@@ -14,8 +15,7 @@ namespace Nt.Tests.Syntax.Actions
         [Fact]
         public void AddNewRuleAction_Test1()
         {
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("A");
+            var grammar = new Grammar().GetBuilder().AddNonTerminal("A").Build();
 
             var symbols = new SymbolsList(SymbolFactory, ["A"]);
             var context = new AutomatonContext();
@@ -30,8 +30,7 @@ namespace Nt.Tests.Syntax.Actions
         [Fact]
         public void AddNewRuleAction_Test2()
         {
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("A");
+            var grammar = new Grammar().GetBuilder().AddNonTerminal("A").Build();
 
             var symbols = new SymbolsList(SymbolFactory, ["B"]);
             var context = new AutomatonContext();

--- a/Tests/Actions/AddRegExSymbolActionTest.cs
+++ b/Tests/Actions/AddRegExSymbolActionTest.cs
@@ -5,6 +5,7 @@ using Nt.Parser.Structures;
 using Nt.Syntax.Automaton;
 using Nt.Parser.Symbols;
 using static Nt.Tests.Syntax.SyntaxTestUtils;
+using Nt.Syntax.Builders;
 
 namespace Nt.Tests.Syntax.Actions
 {
@@ -17,8 +18,7 @@ namespace Nt.Tests.Syntax.Actions
         {
             var symbols = new SymbolsList(SymbolFactory, ["S", "ab*"]);
             var context = new AutomatonContext();
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("S");
+            var grammar = new Grammar().GetBuilder().AddNonTerminal("S").Build();
 
             var newaction = new AddNewRegExAction(grammar, context);
             newaction.Perform(new AutomatonToken(symbols.Get(0), 0));
@@ -34,8 +34,7 @@ namespace Nt.Tests.Syntax.Actions
         {
             var symbols = new SymbolsList(SymbolFactory, ["S", "a", "+", "(", "bc", ")", "*"]);
             var context = new AutomatonContext();
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("S");
+            var grammar = new Grammar().GetBuilder().AddNonTerminal("S").Build();
 
             var newaction = new AddNewRegExAction(grammar, context);
             newaction.Perform(new AutomatonToken(symbols.Get(0), 0));
@@ -54,7 +53,7 @@ namespace Nt.Tests.Syntax.Actions
         {
             var symbols = new SymbolsList(SymbolFactory, ["S", "(ab)+"]);
             var context = new AutomatonContext();
-            var grammar = new Grammar();
+            var grammar = new Grammar().GetBuilder().AddNonTerminal("S").Build();
 
             var action = new AddRegExSymbolsAction(grammar, context);
             Assert.Throws<NullRegexException>(() => action.Perform(new AutomatonToken(symbols.Get(1), 0)));
@@ -65,8 +64,7 @@ namespace Nt.Tests.Syntax.Actions
         {
             var symbols = new SymbolsList(SymbolFactory, ["S", "'a"]);
             var context = new AutomatonContext();
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("S");
+            var grammar = new Grammar().GetBuilder().AddNonTerminal("S").Build();
 
             var newaction = new AddNewRegExAction(grammar, context);
             newaction.Perform(new AutomatonToken(symbols.Get(0), 0));
@@ -82,8 +80,7 @@ namespace Nt.Tests.Syntax.Actions
         {
             var symbols = new SymbolsList(SymbolFactory, ["S", "a'b"]);
             var context = new AutomatonContext();
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("S");
+            var grammar = new Grammar().GetBuilder().AddNonTerminal("S").Build();
 
             var newaction = new AddNewRegExAction(grammar, context);
             newaction.Perform(new AutomatonToken(symbols.Get(0), 0));

--- a/Tests/Actions/AddRuleDerivationActionTest.cs
+++ b/Tests/Actions/AddRuleDerivationActionTest.cs
@@ -5,6 +5,7 @@ using Nt.Parser.Symbols;
 using static Nt.Tests.Syntax.SyntaxTestUtils;
 using Nt.Syntax.Structures;
 using Nt.Syntax.Exceptions;
+using Nt.Syntax.Builders;
 
 namespace Nt.Tests.Syntax.Actions
 {
@@ -17,9 +18,10 @@ namespace Nt.Tests.Syntax.Actions
         {
             var symbols = new SymbolsList(SymbolFactory, ["S", "a"]);
             var context = new AutomatonContext();
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("S");
-            grammar.Terminals.Add("a");
+            var grammar = new Grammar().GetBuilder()
+                .AddNonTerminal("S")
+                .AddTerminal("a")
+                .Build();
 
             var newaction = new AddNewRuleAction(grammar, context);
             newaction.Perform(new AutomatonToken(symbols.Get(0), 0));
@@ -36,8 +38,9 @@ namespace Nt.Tests.Syntax.Actions
         {
             var symbols = new SymbolsList(SymbolFactory, ["S", "A"]);
             var context = new AutomatonContext();
-            var grammar = new Grammar();
-            grammar.NonTerminals.AddRange(["S", "A"]);
+            var grammar = new Grammar().GetBuilder()
+                .AddNonTerminals(["S", "A"])
+                .Build();
 
             var newaction = new AddNewRuleAction(grammar, context);
             newaction.Perform(new AutomatonToken(symbols.Get(0), 0));
@@ -54,8 +57,7 @@ namespace Nt.Tests.Syntax.Actions
         {
             var symbols = new SymbolsList(SymbolFactory, ["S", "a"]);
             var context = new AutomatonContext();
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("S");
+            var grammar = new Grammar().GetBuilder().AddNonTerminal("S").Build();
 
             var newaction = new AddNewRuleAction(grammar, context);
             newaction.Perform(new AutomatonToken(symbols.Get(0), 0));
@@ -80,9 +82,10 @@ namespace Nt.Tests.Syntax.Actions
         {
             var symbols = new SymbolsList(SymbolFactory, ["S", "'a"]);
             var context = new AutomatonContext();
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("S");
-            grammar.Terminals.Add("a");
+            var grammar = new Grammar().GetBuilder()
+                .AddNonTerminal("S")
+                .AddTerminal("a")
+                .Build();
 
             var newaction = new AddNewRuleAction(grammar, context);
             newaction.Perform(new AutomatonToken(symbols.Get(0), 0));
@@ -99,9 +102,10 @@ namespace Nt.Tests.Syntax.Actions
         {
             var symbols = new SymbolsList(SymbolFactory, ["S", "a'b"]);
             var context = new AutomatonContext();
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("S");
-            grammar.Terminals.Add("ab");
+            var grammar = new Grammar().GetBuilder()
+                .AddNonTerminal("S")
+                .AddTerminal("ab")
+                .Build();
 
             var newaction = new AddNewRuleAction(grammar, context);
             newaction.Perform(new AutomatonToken(symbols.Get(0), 0));

--- a/Tests/Actions/AddSameRuleActionTest.cs
+++ b/Tests/Actions/AddSameRuleActionTest.cs
@@ -5,6 +5,7 @@ using Nt.Parser.Structures;
 using Nt.Parser.Symbols;
 using static Nt.Tests.Syntax.SyntaxTestUtils;
 using Nt.Syntax.Exceptions;
+using Nt.Syntax.Builders;
 
 namespace Nt.Tests.Syntax.Actions
 {
@@ -17,8 +18,7 @@ namespace Nt.Tests.Syntax.Actions
         {
             var symbols = new SymbolsList(SymbolFactory, ["A"]);
             var context = new AutomatonContext();
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("A");
+            var grammar = new Grammar().GetBuilder().AddNonTerminal("A").Build();
 
             var newaction = new AddNewRuleAction(grammar, context);
             newaction.Perform(new AutomatonToken(symbols.Get(0), 0));
@@ -34,8 +34,7 @@ namespace Nt.Tests.Syntax.Actions
         {
             var symbols = new SymbolsList(SymbolFactory, ["A"]);
             var context = new AutomatonContext();
-            var grammar = new Grammar();
-            grammar.NonTerminals.Add("A");
+            var grammar = new Grammar().GetBuilder().AddNonTerminal("A").Build();
 
             var action = new AddSameRuleAction(grammar, context);
 

--- a/Tests/Actions/SetAxiomActionTest.cs
+++ b/Tests/Actions/SetAxiomActionTest.cs
@@ -2,6 +2,7 @@
 using Nt.Parser.Symbols;
 using Nt.Syntax.Actions;
 using Nt.Syntax.Automaton;
+using Nt.Syntax.Builders;
 using Nt.Syntax.Exceptions;
 using Nt.Syntax.Structures;
 
@@ -15,8 +16,7 @@ namespace Nt.Tests.Syntax.Actions
         public void SetAxiomAction_Test1()
         {
             var symbols = new SymbolsList(SymbolFactory, ["A", "B", "C"]);
-            var grammar = new Grammar();
-            grammar.NonTerminals.AddRange(["A", "B", "C"]);
+            var grammar = new Grammar().GetBuilder().AddNonTerminals(["A", "B", "C"]).Build();
 
             var action = new SetAxiomAction(grammar);
             action.Perform(new AutomatonToken(symbols.Get(2), 1));
@@ -29,8 +29,7 @@ namespace Nt.Tests.Syntax.Actions
         public void SetAxiomAction_Test2()
         {
             var symbols = new SymbolsList(SymbolFactory, ["A", "B", "C"]);
-            var grammar = new Grammar();
-            grammar.NonTerminals.AddRange(["A", "B"]);
+            var grammar = new Grammar().GetBuilder().AddNonTerminals(["A", "B"]).Build();
 
             var action = new SetAxiomAction(grammar);
             Assert.Throws<UnregisteredNonTerminalException>(() => action.Perform(new AutomatonToken(symbols.Get(2), 1)));

--- a/Tests/Exportation/UtilsTest.cs
+++ b/Tests/Exportation/UtilsTest.cs
@@ -1,0 +1,285 @@
+﻿using Nt.Parser.Symbols;
+using Nt.Syntax.Exportation;
+using Nt.Syntax.Structures;
+using Nt.Syntax.Builders;
+using static Nt.Syntax.Exportation.ExportationMethods;
+using Nt.Parser.Structures;
+
+namespace Nt.Tests.Syntax.Exportation
+{
+    public class UtilsTest
+    {
+        readonly SymbolFactory factory = new SymbolFactory();
+
+
+        // Symbols
+
+        [Fact]
+        public void Symbols_Reorder_ShouldReturnOriginalOrder()
+        {
+            var symbols = new SymbolsList(factory);
+            symbols.AddRange(["B", "A", "C"]);
+
+            var result = Reorder(symbols.GetSymbols(), ExportationMode.Original);
+
+            Assert.Equal(3, result.Count);
+            Assert.Equal(symbols.Get(0), result[0]);
+            Assert.Equal(symbols.Get(1), result[1]);
+            Assert.Equal(symbols.Get(2), result[2]);
+        }
+
+        [Fact]
+        public void Symbols_Reorder_ShouldReturnAlphabeticalOrder()
+        {
+            var symbols = new SymbolsList(factory);
+            symbols.AddRange(["B", "A", "C"]);
+
+            var result = Reorder(symbols.GetSymbols(), ExportationMode.Alphabetical);
+
+            Assert.Equal(3, result.Count);
+            Assert.Equal(symbols.Get(1), result[0]);
+            Assert.Equal(symbols.Get(0), result[1]);
+            Assert.Equal(symbols.Get(2), result[2]);
+        }
+
+        [Fact]
+        public void Symbols_Reorder_ShouldGroupSymbols()
+        {
+            var symbols = new SymbolsList(factory);
+            symbols.AddRange(["A", "B", "BA", "AB"]);
+
+            var result = Reorder(symbols.GetSymbols(), ExportationMode.Grouped);
+
+            Assert.Equal(4, result.Count);
+            Assert.Equal(symbols.Get(0), result[0]);
+            Assert.Equal(symbols.Get(3), result[1]);
+            Assert.Equal(symbols.Get(1), result[2]);
+            Assert.Equal(symbols.Get(2), result[3]);
+        }
+
+        [Fact]
+        public void Symbols_Reorder_ShouldNotReorderIfNoCommonRoot()
+        {
+            var symbols = new SymbolsList(factory);
+            symbols.AddRange(["AB", "AC"]);
+
+            var result = Reorder(symbols.GetSymbols(), ExportationMode.Grouped);
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(symbols.Get(0), result[0]);
+            Assert.Equal(symbols.Get(1), result[1]);
+        }
+
+        [Fact]
+        public void Symbols_Reorder_ShouldGroupSymbolsButConserveOrder()
+        {
+            var symbolA1 = new Symbol("A");
+            var symbolA2 = new Symbol("A1");
+            var symbolA3 = new Symbol("A2");
+            var symbolB1 = new Symbol("B");
+            var symbolB2 = new Symbol("B1");
+            var symbolB3 = new Symbol("B2");
+            var symbols = new List<ISymbol> { symbolA1, symbolB1, symbolA2, symbolA3, symbolB2, symbolB3 };
+
+            var result = Reorder(symbols, ExportationMode.Grouped);
+
+            Assert.Equal(6, result.Count);
+            Assert.Equal(symbolA1, result[0]);
+            Assert.Equal(symbolA2, result[1]);
+            Assert.Equal(symbolA3, result[2]);
+            Assert.Equal(symbolB1, result[3]);
+            Assert.Equal(symbolB2, result[4]);
+            Assert.Equal(symbolB3, result[5]);
+        }
+
+        // Rules
+
+        [Fact]
+        public void Rules_Reorder_ShouldReturnOriginalOrder()
+        {
+            var grammar = new Grammar();
+            grammar.GetBuilder()
+                .Add(new Rule(grammar))
+                .Add(new Rule(grammar))
+                .Add(new Rule(grammar));
+
+            var result = Reorder(grammar.Rules.ToList(), ExportationMode.Original);
+
+            Assert.Equal(grammar.Rules.Get(0), result[0]);
+            Assert.Equal(grammar.Rules.Get(1), result[1]);
+            Assert.Equal(grammar.Rules.Get(2), result[2]);
+        }
+
+        [Fact]
+        public void Rules_Reorder_ShouldReturnAlphabeticalOrder()
+        {
+            var grammar = new Grammar()
+                .GetBuilder()
+                .AddNonTerminals(["B", "A", "C"])
+                .Build();
+            grammar.GetBuilder()
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("B"), -1)).Build())
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("A"), -1)).Build())
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("C"), -1)).Build());
+
+            var result = Reorder(grammar.Rules.ToList(), ExportationMode.Alphabetical);
+
+            Assert.Equal(grammar.Rules.Get(1), result[0]);
+            Assert.Equal(grammar.Rules.Get(0), result[1]);
+            Assert.Equal(grammar.Rules.Get(2), result[2]);
+        }
+
+        [Fact]
+        public void Rules_Reorder_ShouldGroupRules()
+        {
+            var grammar = new Grammar();
+            grammar.GetBuilder()
+                .AddNonTerminals(["A", "B", "BA", "AB"])
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("A"), -1)).Build())
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("B"), -1)).Build())
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("BA"), -1)).Build())
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("AB"), -1)).Build());
+
+            var result = Reorder(grammar.Rules.ToList(), ExportationMode.Grouped);
+
+            Assert.Equal(grammar.Rules.Get(0), result[0]);
+            Assert.Equal(grammar.Rules.Get(3), result[1]);
+            Assert.Equal(grammar.Rules.Get(1), result[2]);
+            Assert.Equal(grammar.Rules.Get(2), result[3]);
+        }
+
+        [Fact]
+        public void Rules_Reorder_ShouldNotReorderIfNoCommonRoot()
+        {
+            var grammar = new Grammar();
+            grammar.GetBuilder()
+                .AddNonTerminals(["AB", "AC"])
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("AB"), -1)).Build())
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("AC"), -1)).Build());
+
+            var result = Reorder(grammar.Rules.ToList(), ExportationMode.Grouped);
+
+            Assert.Equal(grammar.Rules.Get(0), result[0]);
+            Assert.Equal(grammar.Rules.Get(1), result[1]);
+        }
+
+        [Fact]
+        public void Rule_Reorder_ShouldGroupRulesButConserveOrder()
+        {
+            var grammar = new Grammar();
+            grammar.GetBuilder()
+                .AddNonTerminals(["A", "A1", "A2", "B", "B1", "B2"])
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("A"), -1)).Build())
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("B"), -1)).Build())
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("A1"), -1)).Build())
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("A2"), -1)).Build())
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("B1"), -1)).Build())
+                .Add(new Rule(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("B2"), -1)).Build());
+
+            var result = Reorder(grammar.Rules.ToList(), ExportationMode.Grouped);
+
+            Assert.Equal(6, result.Count);
+            Assert.Equal(grammar.Rules.Get(0), result[0]);
+            Assert.Equal(grammar.Rules.Get(2), result[1]);
+            Assert.Equal(grammar.Rules.Get(3), result[2]);
+            Assert.Equal(grammar.Rules.Get(1), result[3]);
+            Assert.Equal(grammar.Rules.Get(4), result[4]);
+            Assert.Equal(grammar.Rules.Get(5), result[5]);
+        }
+
+
+
+        // Regular Expressions
+
+        [Fact]
+        public void RegularExpressions_Reorder_ShouldReturnOriginalOrder()
+        {
+            var grammar = new Grammar();
+            grammar.GetBuilder()
+                .Add(new RegularExpression(grammar))
+                .Add(new RegularExpression(grammar))
+                .Add(new RegularExpression(grammar));
+
+            var result = Reorder(grammar.RegularExpressions.ToList(), ExportationMode.Original);
+
+            Assert.Equal(grammar.RegularExpressions.Get(0), result[0]);
+            Assert.Equal(grammar.RegularExpressions.Get(1), result[1]);
+            Assert.Equal(grammar.RegularExpressions.Get(2), result[2]);
+        }
+
+        [Fact]
+        public void RegularExpressions_Reorder_ShouldReturnAlphabeticalOrder()
+        {
+            var grammar = new Grammar();
+            grammar.GetBuilder()
+                .AddNonTerminals(["B", "A", "C"])
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("B"), -1)).Build())
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("A"), -1)).Build())
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("C"), -1)).Build());
+
+            var result = Reorder(grammar.RegularExpressions.ToList(), ExportationMode.Alphabetical);
+
+            Assert.Equal(grammar.RegularExpressions.Get(1), result[0]);
+            Assert.Equal(grammar.RegularExpressions.Get(0), result[1]);
+            Assert.Equal(grammar.RegularExpressions.Get(2), result[2]);
+        }
+
+        [Fact]
+        public void RegularExpressions_Reorder_ShouldGroupRegularExpressions()
+        {
+            var grammar = new Grammar();
+            grammar.GetBuilder()
+                .AddNonTerminals(["A", "B", "BA", "AB"])
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("A"), -1)).Build())
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("B"), -1)).Build())
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("BA"), -1)).Build())
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("AB"), -1)).Build());
+
+            var result = Reorder(grammar.RegularExpressions.ToList(), ExportationMode.Grouped);
+
+            Assert.Equal(grammar.RegularExpressions.Get(0), result[0]);
+            Assert.Equal(grammar.RegularExpressions.Get(3), result[1]);
+            Assert.Equal(grammar.RegularExpressions.Get(1), result[2]);
+            Assert.Equal(grammar.RegularExpressions.Get(2), result[3]);
+        }
+
+        [Fact]
+        public void RegularExpressions_Reorder_ShouldNotReorderIfNoCommonRoot()
+        {
+            var grammar = new Grammar();
+            grammar.GetBuilder()
+                .AddNonTerminals(["AB", "AC"])
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("AB"), -1)).Build())
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("AC"), -1)).Build());
+            var result = Reorder(grammar.RegularExpressions.ToList(), ExportationMode.Grouped);
+            Assert.Equal(grammar.RegularExpressions.Get(0), result[0]);
+            Assert.Equal(grammar.RegularExpressions.Get(1), result[1]);
+        }
+
+        [Fact]
+        public void RegularExpressions_Reorder_ShouldGroupRegularExpressionsButConserveOrder()
+        {
+            var grammar = new Grammar();
+            grammar.GetBuilder()
+                .AddNonTerminals(["A", "A1", "A2", "B", "B1", "B2"])
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("A"), -1)).Build())
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("B"), -1)).Build())
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("A1"), -1)).Build())
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("A2"), -1)).Build())
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("B1"), -1)).Build())
+                .Add(new RegularExpression(grammar).GetBuilder().SetToken(new NonTerminal(new Symbol("B2"), -1)).Build());
+
+            var result = Reorder(grammar.RegularExpressions.ToList(), ExportationMode.Grouped);
+
+            Assert.Equal(6, result.Count);
+            Assert.Equal(grammar.RegularExpressions.Get(0), result[0]);
+            Assert.Equal(grammar.RegularExpressions.Get(2), result[1]);
+            Assert.Equal(grammar.RegularExpressions.Get(3), result[2]);
+            Assert.Equal(grammar.RegularExpressions.Get(1), result[3]);
+            Assert.Equal(grammar.RegularExpressions.Get(4), result[4]);
+            Assert.Equal(grammar.RegularExpressions.Get(5), result[5]);
+        }
+
+
+    }
+}

--- a/Tests/SyntaxTestUtils.cs
+++ b/Tests/SyntaxTestUtils.cs
@@ -5,7 +5,7 @@ namespace Nt.Tests.Syntax
 {
     public class SyntaxTestUtils
     {
-        private static bool DerivationEquals(Grammar grammar, Derivation derivation, List<string> referenceList)
+        private static bool DerivationEquals(Grammar grammar, RuleDerivation derivation, List<string> referenceList)
         {
             if (referenceList.Count != derivation.Count) return false;
             for (int i = 0; i < derivation.Count; i++)
@@ -16,10 +16,10 @@ namespace Nt.Tests.Syntax
         }
 
         #region Grammar checking
-        internal static void AssertTokens(SymbolsList symbols, List<string> reference)
+        internal static void AssertTokens(GrammarSymbolsSet symbols, List<string> reference)
         {
-            Assert.Equal(reference.Count, symbols.GetCount());
-            for (int i = 0; i < symbols.GetCount(); i++)
+            Assert.Equal(reference.Count, symbols.Count);
+            for (int i = 0; i < symbols.Count; i++)
             {
                 Assert.Equal(reference[i], symbols.Get(i).Name);
             }


### PR DESCRIPTION
# Builders
Add builder for object `Grammar`, `Rule` and `Regular expression`
The old methods no longer exists. Building a new grammar requires the associated builder.
See documentation for more details.

# Exportation
`Grammar` object can be exported as a string and reordered in the meantime.
Reordering modes are:
- Default (no reordering)
- Alphabetical
- Grouped 